### PR TITLE
Add setup.py and update doctests to run on Python2.7 and 3.x

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,23 @@
+Copyright (c) 2009-2010 Sebastian Kraemer, basti.kr@gmail.com
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,10 @@
+graft docs
+graft boolean
+
+include LICENSE.txt
+include setup.py
+include setup.cfg
+include README.md
+include MANIFEST.in
+
+global-exclude *.py[co] __pycache__

--- a/README.md
+++ b/README.md
@@ -1,16 +1,11 @@
 boolean.py
 ==========
 
-"boolean.py" is a single python module implementing a boolean algebra. It
+"boolean.py" is a small library implementing a boolean algebra. It
 defines two base elements, TRUE and FALSE, and a class Symbol which can take
 on one of these two values. Calculations are done in terms of AND, OR and
 NOT - other compositions like XOR and NAND are not implemented.
-
-
-Download
---------
-
-$ git clone git://github.com/bastikr/boolean.py.git
+It runs on Python 2.7 and Python 3.
 
 
 Documentation
@@ -19,9 +14,21 @@ Documentation
 http://readthedocs.org/docs/booleanpy/en/latest/
 
 
+Download and installation
+-------------------------
+
+boolean.py is not yet in Pypi.
+
+Locally from a checkout or download::
+    git clone git://github.com/bastikr/boolean.py.git
+    cd boolean.py
+    pip install .
+
+Remotely::
+    pip install https://github.com/bastikr/boolean.py/archive/master.zip
+
+
 License
 -------
 
 Simplified BSD License
-
-

--- a/boolean/__init__.py
+++ b/boolean/__init__.py
@@ -1,0 +1,33 @@
+"""
+Boolean Algebra.
+
+This module defines a Boolean Algebra over the set {TRUE, FALSE} with boolean
+variables and the boolean functions AND, OR, NOT. For extensive documentation
+look either into the docs directory or view it online, at
+https://booleanpy.readthedocs.org/en/latest/.
+
+Copyright (c) 2009-2010 Sebastian Kraemer, basti.kr@gmail.com
+Released under revised BSD license.
+"""
+
+from __future__ import absolute_import
+
+from boolean.boolean import Algebra
+from boolean.boolean import BooleanAlgebra
+from boolean.boolean import BooleanDomain
+from boolean.boolean import BooleanOperations
+from boolean.boolean import Expression
+from boolean.boolean import BaseElement
+from boolean.boolean import Symbol
+from boolean.boolean import Function
+from boolean.boolean import DualBase
+
+from boolean.boolean import FALSE
+from boolean.boolean import TRUE
+from boolean.boolean import AND
+from boolean.boolean import NOT
+from boolean.boolean import OR
+
+from boolean.boolean import normalize
+from boolean.boolean import symbols
+from boolean.boolean import parse

--- a/boolean/boolean.py
+++ b/boolean/boolean.py
@@ -9,6 +9,9 @@ https://booleanpy.readthedocs.org/en/latest/.
 Copyright (c) 2009-2010 Sebastian Kraemer, basti.kr@gmail.com
 Released under revised BSD license.
 """
+
+from __future__ import absolute_import
+
 import itertools
 import collections
 

--- a/boolean/test_boolean.py
+++ b/boolean/test_boolean.py
@@ -1,3 +1,14 @@
+"""
+Boolean Algebra.
+
+Tests
+
+Copyright (c) 2009-2010 Sebastian Kraemer, basti.kr@gmail.com
+Released under revised BSD license.
+"""
+
+from __future__ import absolute_import
+
 import unittest
 import boolean
 
@@ -452,7 +463,7 @@ class BooleanAlgebraTestCase(unittest.TestCase):
 
         a = ConstFilter(True)
         b = ConstFilter(False)
-        self.assertEqual(type(a + b), Filter)
+        self.assertTrue(isinstance(a + b, Filter))
         self.assertEqual((a + b).eval(), boolean.TRUE)
         self.assertEqual((a * b).eval(), boolean.FALSE)
 

--- a/docs/users_guide.rst
+++ b/docs/users_guide.rst
@@ -23,15 +23,18 @@ defines two base elements, *TRUE* and *FALSE*, and a class :class:`Symbol`
 which can take on one of these two values. Calculations are done in terms
 of AND, OR and NOT - other compositions like XOR and NAND are not implemented.
 
+
 Installation
 ------------
 
-At the moment there is no installable package available - this will be done
-when the module was tested a little bit more. However, it's easy enough to get
-it running by downloading **boolean.py** and either adding it's location to the
-*PYTHONPATH* or starting the python interpreter in the same directory.
+Locally from a checkout or download::
+    pip install .
 
-Then **boolean.py** can be used by simply importing it:
+Remotely::
+    pip install https://github.com/bastikr/boolean.py/archive/master.zip
+
+
+Then import it:
 
 .. doctest:: boolean
 
@@ -71,29 +74,32 @@ These defined Symbols can be composed in different ways:
     >>> x*y
     AND(Symbol('x'), Symbol('y'))
     >>> OR(NOT(y), x)
-    OR(NOT(Symbol('y')), Symbol('x'))
+    OR(Symbol('x'), NOT(Symbol('y')))
     >>> x + ~y
-    OR(NOT(Symbol('y')), Symbol('x'))
+    OR(Symbol('x'), NOT(Symbol('y')))
 
 The output above maybe seems to be a little long, but this is only the result
 of :func:`repr`. Printing looks a lot nicer:
 
 .. doctest:: boolean
 
-    >>> print x+y
+    >>> print(x+y)
     x+y
 
 Yet another possibility is to parse a string into a boolean expression:
 
 .. doctest:: boolean
 
-    >>> print parse("x+y")
+    >>> print(parse("x+y"))
     x+y
+
+    >>> parse('(apple + banana * (orange + anana * (lemon + cherry)))')
+    OR(Symbol('apple'), AND(Symbol('banana'), OR(Symbol('orange'), AND(Symbol('anana'), OR(Symbol('cherry'), Symbol('lemon'))))))
 
 .. note::
 
     When using :func:`parse` you don't have to define every symbol separately
-    and therefor you can save a bit of typing. This is especially useful when
+    and therefore you can save a bit of typing. This is especially useful when
     using **boolean.py** interactively.
 
 
@@ -105,17 +111,17 @@ simplifications are carried out and then the result is returned:
 
 .. doctest:: boolean
 
-    >>> print x*~x
+    >>> print(x*~x)
     0
-    >>> print x+~x
+    >>> print(x+~x)
     1
-    >>> print x+x
+    >>> print(x+x)
     x
-    >>> print x*x
+    >>> print(x*x)
     x
-    >>> print x*(x+y)
+    >>> print(x*(x+y))
     x
-    >>> print (x*y) + (x*~y)
+    >>> print((x*y) + (x*~y))
     x
 
 In detail the following laws are used recursively on every sub-term of +
@@ -137,14 +143,14 @@ Be aware that you can still have nested expressions:
 
 .. doctest:: boolean
 
-    >>> print ((x+y)*z)+x*y
-    ((x+y)*z)+(x*y)
+    >>> print(((x+y)*z)+x*y)
+    (x*y)+(z*(x+y))
 
 If this automatic evaluation is unwanted, the keyword *eval* can be used:
 
 .. doctest:: boolean
 
-    >>> print AND(x, NOT(x), eval=False)
+    >>> print(AND(x, NOT(x), eval=False))
     x*~x
 
 Since it can be very tedious to write *eval*\=\ :keyword:`False` and the
@@ -153,7 +159,7 @@ be much easier to use the function *parse* instead:
 
 .. doctest:: boolean
 
-    >>> print parse("x*~x", eval=False)
+    >>> print(parse("x*~x", eval=False))
     x*~x
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[bdist_wheel]
+universal = 1
+
+[metadata]
+license_file = LICENSE.txt

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+
+from __future__ import absolute_import
+
+from setuptools import find_packages
+from setuptools import setup
+
+
+long_desc = ''' Boolean Algebra.
+This module defines a Boolean Algebra over the set {TRUE, FALSE} with boolean
+variables and the boolean functions AND, OR, NOT. For extensive documentation
+look either into the docs directory or view it online, at
+https://booleanpy.readthedocs.org/en/latest/
+https://github.com/bastikr/boolean.py
+Copyright (c) 2009-2010 Sebastian Kraemer, basti.kr@gmail.com
+Released under revised BSD license.
+'''
+
+
+setup(
+    name='boolean.py',
+    version='1.0',
+    license='revised BSD license',
+    description='Boolean Algreba',
+    long_description=long_desc,
+    author='Sebastian Kraemer',
+    author_email='basti.kr@gmail.com',
+    url='https://github.com/bastikr/boolean.py',
+    packages=find_packages(),
+    include_package_data=True,
+    zip_safe=False,
+    test_loader='unittest:TestLoader',
+    test_suite='boolean.test_boolean',
+    keywords='boolean expression, boolean algebra, logic, expression parser',
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: BSD License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Topic :: Scientific/Engineering :: Mathematics',
+        'Topic :: Software Development :: Compilers',
+        'Topic :: Software Development :: Libraries',
+        'Topic :: Utilities',
+    ],
+)


### PR DESCRIPTION
For your consideration:
* Move boolean.py to a proper package with an __init__ 
* Add revised BSD license text and updated notices, for you to review for accuracy
* Create setup.py and config for tests and wheels. Use `python setup.py test` for testing
* Updated README, doc and doctests for Python 2 and 3.
