### PR TITLE
TRUE and FALSE act as booleans

### DIFF
--- a/boolean/boolean.py
+++ b/boolean/boolean.py
@@ -330,6 +330,8 @@ class _TRUE(BaseElement):
     _str = "1"
     _repr = "TRUE"
 
+    __nonzero__ = __bool__ = lambda s: True
+
 
 class _FALSE(BaseElement):
     """
@@ -339,6 +341,8 @@ class _FALSE(BaseElement):
     """
     _str = "0"
     _repr = "FALSE"
+
+    __nonzero__ = __bool__ = lambda s: False
 
 
 # Initialize two singletons which will be used as base elements for the


### PR DESCRIPTION
Evaluating bool(TRUE) should be (and currently) is True, but bool(FALSE) should, I think, also be False, but it isn't. I added bool() (and nozero() for Python 2) to TRUE and FALSE classes. Fixes issue #12