### PR TITLE
Allow custom Symbol class

### DIFF
--- a/boolean/boolean.py
+++ b/boolean/boolean.py
@@ -1008,7 +1008,17 @@ PRECEDENCE = {
 }
 
 
-def parse(expr, simplify=True, symbol_class=None):
+def issymbolchar(char, pos):
+    """
+    Determines if the passed character is a valid symbol character.
+    """
+    if pos == 0:
+        return char.isalpha() or char == "_"
+    else:
+        return char.isalnum() or char in (".", ":", "_")
+
+
+def parse(expr, simplify=True, symbol_class=None, issymbolchar=issymbolchar):
     """
     Returns a boolean expression created from the given string.
     """
@@ -1049,9 +1059,9 @@ def parse(expr, simplify=True, symbol_class=None):
             ast.append(TRUE)
         elif char == "0":
             ast.append(FALSE)
-        elif char.isalpha():
+        elif issymbolchar(char, 0):
             j = 1
-            while i + j < length and expr[i + j].isalnum():
+            while i + j < length and issymbolchar(expr[i + j], j):
                 j += 1
             ast.append(symbol_class(expr[i:i + j]))
             i += j - 1

--- a/boolean/boolean.py
+++ b/boolean/boolean.py
@@ -1008,12 +1008,15 @@ PRECEDENCE = {
 }
 
 
-def parse(expr, simplify=True):
+def parse(expr, simplify=True, symbol_class=None):
     """
     Returns a boolean expression created from the given string.
     """
     if not isinstance(expr, basestring):
         raise TypeError("Argument must be string but it is %s." % type(expr))
+
+    if symbol_class is None:
+        symbol_class = Symbol
 
     def start_operation(ast, operation):
         """
@@ -1050,7 +1053,7 @@ def parse(expr, simplify=True):
             j = 1
             while i + j < length and expr[i + j].isalnum():
                 j += 1
-            ast.append(Symbol(expr[i:i + j]))
+            ast.append(symbol_class(expr[i:i + j]))
             i += j - 1
         elif char == "(":
             ast = [ast, "("]


### PR DESCRIPTION
Allow swapping the Symbol class used during parsing. Also, Symbol knows what characters it takes (for me I needed dot, colons and slashes as part of the symbols, so that's what the default Symbol takes too now). This addresses something it was mentioned in issue #9 by @pombredanne.