### PR TITLE
Define if a Symbol evaluates to TRUE or FALSE

### DIFF
--- a/boolean/test_boolean.py
+++ b/boolean/test_boolean.py
@@ -457,6 +457,22 @@ class BooleanAlgebraTestCase(unittest.TestCase):
         self.assertEqual((a * b).eval(), boolean.FALSE)
 
 
+class BooleanEvalTestCase(unittest.TestCase):
+
+    def test_eval(self):
+        f = boolean.parse('a&b', eval=False)
+        self.assertEqual(f.eval(dict(a=0, b=0)), boolean.FALSE)
+        self.assertEqual(f.eval(dict(a=0, b=1)), boolean.FALSE)
+        self.assertEqual(f.eval(dict(a=1, b=0)), boolean.FALSE)
+        self.assertEqual(f.eval(dict(a=1, b=1)), boolean.TRUE)
+
+        f = boolean.parse('a|b', eval=False)
+        self.assertEqual(f.eval(dict(a=0, b=0)), boolean.FALSE)
+        self.assertEqual(f.eval(dict(a=0, b=1)), boolean.TRUE)
+        self.assertEqual(f.eval(dict(a=1, b=0)), boolean.TRUE)
+        self.assertEqual(f.eval(dict(a=1, b=1)), boolean.TRUE)
+
+
 if __name__ == "__main__":
     unittest.main()
 


### PR DESCRIPTION
I'm using the Boolean expressions to pass Boolean rules and parsing them (and simplifying them) and then, how do I tell the expression to use certain symbols as `True` or `False` to give me end result of the evaluated symbols?

I currently added some changes to `eval()` to be able to pass a mapping of symbols to TRUE/FALSE during the evaluation. `eval()` received `**evalkwargs`, which I guessed it was for the purpose of passing that mapping of symbols, as it only seemed intuitive it would, but it didn't do anything with them. Also, once expressions are flagged as canonical, `eval()` a second time doesn't do anything. So I changed `eval()` to save the dictionary object in `**evalkwargs` in a variable so next time I call `eval()` it returns immediately only if the saved `evalkwargs` is equal to the passed one (thus it's already been processed under that `evalkwargs` context as canonical) and I also use the passed `evalkwargs` in the Symbol's `eval()` as the symbol mapping to look for the value of symbol, so it returns either `TRUE` or `FALSE`, if it's there, or the symbol itself (`self`), if it's not. I added a few tests. This fixes issue #13.