### PR TITLE
Alternative parser using a standard tokenizer with multiple customization possible

### DIFF
--- a/boolean/boolean.py
+++ b/boolean/boolean.py
@@ -1054,8 +1054,9 @@ def tokenizer(expr):
             continue
 
         is_symbol = False
-        if tok in OPS:
+        if tok.lower() in OPS:
             is_symbol = False
+            tok = tok.lower()
         elif toktype == tokenize.NAME or tok in ZERO_OR_ONE:
             is_symbol = True
         else:

--- a/boolean/test_boolean.py
+++ b/boolean/test_boolean.py
@@ -33,9 +33,9 @@ class ExpressionTestCase(unittest.TestCase):
 
         expr_str = """(a or ~ b +_c  ) and #some comment 
                       d & ( ! e_ 
-                      | (AND * g or 1 or 0) ) """
+                      | (my * g OR 1 or 0) ) AND that """
 
-        expr = boolean.parse(expr_str, eval=False)
+        expr = boolean.parse(expr_str, eval=False, symbol=MySymbol)
 
         expected = boolean.AND(
             boolean.OR(
@@ -48,7 +48,7 @@ class ExpressionTestCase(unittest.TestCase):
                 boolean.NOT(MySymbol('e_')),
                 boolean.OR(
                     boolean.AND(
-                        MySymbol('AND'),
+                        MySymbol('my'),
                         MySymbol('g'),
                         eval=False
                     ),
@@ -56,6 +56,7 @@ class ExpressionTestCase(unittest.TestCase):
                     boolean.FALSE,
                     eval=False),
                 eval=False),
+            MySymbol('that'),
             eval=False
         )
 

--- a/boolean/test_boolean.py
+++ b/boolean/test_boolean.py
@@ -37,7 +37,7 @@ class ExpressionTestCase(unittest.TestCase):
                       d & ( ! e_ 
                       | (my * g OR 1 or 0) ) AND that """
 
-        expr = boolean.parse(expr_str, simplify=False, symbol=MySymbol)
+        expr = boolean.parse(expr_str, simplify=False, symbol_class=MySymbol)
 
         expected = boolean.AND(
             boolean.OR(
@@ -62,6 +62,13 @@ class ExpressionTestCase(unittest.TestCase):
             simplify=False
         )
 
+        self.assertEqual(expected, expr)
+
+    def test_parse_recognizes_trueish_and_falsish_symbol_tokens(self):
+        expr_str = 'True or False or None or 0 or 1 or TRue or FalSE or NONe'
+        expr = boolean.parse(expr_str, simplify=False)
+        from boolean import OR, TRUE, FALSE
+        expected = OR(TRUE, FALSE, FALSE, FALSE, TRUE, TRUE, FALSE, FALSE, simplify=False)
         self.assertEqual(expected, expr)
 
     def test_parse_can_use_alternative_tokenizer(self):
@@ -89,12 +96,12 @@ class ExpressionTestCase(unittest.TestCase):
         expr_str = """( Custom OR regular ) ALSO ( 
                       not_custom NEITHER standard )
                     """
-        expr = boolean.parse(expr_str, simplify=False, tokenizer=tokenizer)
+        expr = boolean.parse(expr_str, simplify=False, tokenizer=tokenizer, symbol_class=MySymbol)
         expected = boolean.AND(
                         boolean.OR(
                             CustomSymbol('Custom'),
-                            boolean.Symbol('regular')),
-                        boolean.Symbol('not_custom'))
+                            MySymbol('regular')),
+                        MySymbol('not_custom'))
         self.assertEqual(expected, expr)
 
 


### PR DESCRIPTION
This is rough proof of concept that supports more or less:
* #11 and #18 (alternative operators) 
* #9  (feeding sequences to the parser with via custom tokenizers)
* #19 (custom symbols)

It has these benefits IMHO:
 * Use the standard lib "tokenize" module
 * Accept arbitrary Python names as symbols
 * Support `and`, `not`, `or`, `!`, `~`, `+`, `*`, `&`, `|` as operators in any combination
 * Parse comments and multi-line expressions
 * Accept any white spaces
 * Errors are reported with row and columns
 * Accept alternative tokenizer, allowing to have custom 
   symbols and operators
 * Accept custom symbols class