### PR TITLE
Evaluate expression as boolean

### DIFF
--- a/boolean/boolean.py
+++ b/boolean/boolean.py
@@ -263,6 +263,14 @@ class Expression(object):
 
     __add__ = __or__
 
+    def __bool__(self):
+        simplified = self.simplify()
+        if simplified is self:
+            raise TypeError("Cannot evaluate as boolean: %s" % simplified)
+        return bool(simplified)
+
+    __nonzero__ = __bool__
+
 
 class BaseElement(Expression):
     """

--- a/boolean/boolean.py
+++ b/boolean/boolean.py
@@ -264,10 +264,7 @@ class Expression(object):
     __add__ = __or__
 
     def __bool__(self):
-        simplified = self.simplify()
-        if simplified is self:
-            raise TypeError("Cannot evaluate as boolean: %s" % simplified)
-        return bool(simplified)
+        raise TypeError("Cannot evaluate expression as boolean, please simplify using simplify() or subs()")
 
     __nonzero__ = __bool__
 

--- a/boolean/test_boolean.py
+++ b/boolean/test_boolean.py
@@ -483,8 +483,10 @@ class BooleanBoolTestCase(unittest.TestCase):
         expr = a * b + c
         self.assertRaises(TypeError, bool, expr.subs({a: boolean.TRUE}, simplify=False))
         self.assertRaises(TypeError, bool, expr.subs({b: boolean.TRUE}, simplify=False))
-        self.assertTrue(expr.subs({c: boolean.TRUE}, simplify=False))
-        self.assertTrue(expr.subs({a: boolean.TRUE, b: boolean.TRUE}, simplify=False))
+        self.assertRaises(TypeError, bool, expr.subs({c: boolean.TRUE}, simplify=False))
+        self.assertRaises(TypeError, bool, expr.subs({a: boolean.TRUE, b: boolean.TRUE}, simplify=False))
+        self.assertTrue(expr.subs({c: boolean.TRUE}, simplify=True))
+        self.assertTrue(expr.subs({a: boolean.TRUE, b: boolean.TRUE}, simplify=True))
 
 
 if __name__ == "__main__":

--- a/boolean/test_boolean.py
+++ b/boolean/test_boolean.py
@@ -181,8 +181,8 @@ class NOTTestCase(unittest.TestCase):
         self.assertTrue(~a == ~a)
         self.assertFalse(a == boolean.parse("~~a", simplify=False))
         self.assertTrue(a == ~~a)
-        self.assertTrue(~a, ~~~a)
-        self.assertTrue(a, ~~~~a)
+        self.assertTrue(~a == ~~~a)
+        self.assertTrue(a == ~~~~a)
         self.assertTrue(~(a * a * a) == ~(a * a * a))
 
     def test_cancel(self):
@@ -474,6 +474,17 @@ class BooleanAlgebraTestCase(unittest.TestCase):
         self.assertTrue(isinstance(a + b, Filter))
         self.assertEqual((a + b).simplify(), boolean.TRUE)
         self.assertEqual((a * b).simplify(), boolean.FALSE)
+
+
+class BooleanBoolTestCase(unittest.TestCase):
+
+    def test_bool(self):
+        a, b, c = boolean.symbols("a", "b", "c")
+        expr = a * b + c
+        self.assertRaises(TypeError, bool, expr.subs({a: boolean.TRUE}, simplify=False))
+        self.assertRaises(TypeError, bool, expr.subs({b: boolean.TRUE}, simplify=False))
+        self.assertTrue(expr.subs({c: boolean.TRUE}, simplify=False))
+        self.assertTrue(expr.subs({a: boolean.TRUE, b: boolean.TRUE}, simplify=False))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Improves on what's being commented in issue #12: Expression should evaluate to True/False only when it can do so, otherwise raise an exception.

This patch includes a couple other fixes in the tests (that immediately jumped with the change), which are also addressed in pull request #23 