### PR TITLE
Fix other misuse of assertTrue()

### DIFF
--- a/boolean/test_boolean.py
+++ b/boolean/test_boolean.py
@@ -138,7 +138,7 @@ class SymbolTestCase(unittest.TestCase):
     def test_printing(self):
         self.assertTrue(str(boolean.Symbol("a")) == "a")
         self.assertTrue(str(boolean.Symbol(1)) == "1")
-        self.assertTrue(repr(boolean.Symbol("a")), "Symbol('a')")
+        self.assertTrue(repr(boolean.Symbol("a")) == "Symbol('a')")
         self.assertTrue(repr(boolean.Symbol(1)) == "Symbol(1)")
 
 


### PR DESCRIPTION
I've looked all over the tests and I found only another misuse of `assertTrue()`. I think we'll need to change those to `assertEqual()` later, but I'm waiting until the tokenizer lands (as it adds/touches tests too much). For now, this fixes the current tests.