### PR TITLE
Variadic arguments for __new__() needed for custom Symbols

### DIFF
--- a/boolean/boolean.py
+++ b/boolean/boolean.py
@@ -394,7 +394,7 @@ class Symbol(Expression):
 
     _obj = None
 
-    def __new__(cls, obj=None, simplify=True):
+    def __new__(cls, *args, **kwargs):
         return object.__new__(cls)
 
     def __init__(self, obj=None, simplify=True):

--- a/boolean/test_boolean.py
+++ b/boolean/test_boolean.py
@@ -820,5 +820,18 @@ class BooleanBoolTestCase(unittest.TestCase):
         self.assertTrue(expr.subs({a: boolean.TRUE, b: boolean.TRUE}, simplify=True))
 
 
+class CustomSymbolTestCase(unittest.TestCase):
+
+    def test_custom_symbol(self):
+        class CustomSymbol(boolean.Symbol):
+            def __init__(self, name, value='value'):
+                self.var = value
+                super(CustomSymbol, self).__init__(name)
+        try:
+            CustomSymbol('a', value='This is A')
+        except TypeError as e:
+            self.fail(e)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
When starting to use the new library with the changes we've made, I realized custom symbols that take different arguments need to receive variadic arguments in `__new__()`. For consistency, all three `__new__()` were changed.