### PR TITLE
#33 Do not use __new__ anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@ boolean.py
 ==========
 
 "boolean.py" is a small library implementing a boolean algebra. It
-defines two base elements, TRUE and FALSE, and a class Symbol which can take
+defines two base elements, TRUE and FALSE, and a Symbol class that can take
 on one of these two values. Calculations are done in terms of AND, OR and
-NOT - other compositions like XOR and NAND are not implemented.
+NOT - other compositions like XOR and NAND are not implemented but can be
+emulated with AND or and NOT. 
 Expressions are constructed from parsed strings or in Python.
 
 It runs on Python 2.7 and Python 3.
@@ -15,11 +16,12 @@ Example
 -------
 ```
     >>> import boolean
-    >>> expression1 = boolean.parse(u'apple and (oranges or banana) and not banana', simplify=False)
+    >>> algebra = boolean.BooleanAlgebra()
+    >>> expression1 = algebra.parse(u'apple and (oranges or banana) and not banana', simplify=False)
     >>> expression1
     AND(Symbol('apple'), OR(Symbol('oranges'), Symbol('banana')), NOT(Symbol('banana')))
 
-    >>> expression2 = boolean.parse(u'(oranges | banana) and not banana & apple', simplify=True)
+    >>> expression2 = algebra.parse(u'(oranges | banana) and not banana & apple', simplify=True)
     >>> expression2
     AND(Symbol('apple'), NOT(Symbol('banana')), Symbol('oranges'))
 
@@ -32,12 +34,17 @@ Example
 Documentation
 -------------
 
+Note: this version 2.x is a pre-release and the documentation is not yet up to
+date.
+
 http://readthedocs.org/docs/booleanpy/en/latest/
+
 
 
 Download and installation
 -------------------------
-    pip install boolean.py
+
+    `pip install boolean.py`
 
 
 License

--- a/boolean/__init__.py
+++ b/boolean/__init__.py
@@ -12,7 +12,7 @@ Released under revised BSD license.
 
 from __future__ import absolute_import
 
-from boolean.boolean import Expression
+from boolean.boolean import BooleanAlgebra
 from boolean.boolean import Symbol
 
 from boolean.boolean import AND

--- a/boolean/__init__.py
+++ b/boolean/__init__.py
@@ -22,7 +22,6 @@ from boolean.boolean import OR
 from boolean.boolean import TRUE
 from boolean.boolean import FALSE
 
-
 from boolean.boolean import TOKEN_TRUE
 from boolean.boolean import TOKEN_FALSE
 from boolean.boolean import TOKEN_SYMBOL

--- a/boolean/__init__.py
+++ b/boolean/__init__.py
@@ -19,9 +19,6 @@ from boolean.boolean import AND
 from boolean.boolean import NOT
 from boolean.boolean import OR
 
-from boolean.boolean import TRUE
-from boolean.boolean import FALSE
-
 from boolean.boolean import TOKEN_TRUE
 from boolean.boolean import TOKEN_FALSE
 from boolean.boolean import TOKEN_SYMBOL

--- a/boolean/__init__.py
+++ b/boolean/__init__.py
@@ -12,28 +12,24 @@ Released under revised BSD license.
 
 from __future__ import absolute_import
 
-from boolean.boolean import Algebra  # NOQA
-from boolean.boolean import BooleanDomain  # NOQA
-from boolean.boolean import BooleanOperations  # NOQA
-from boolean.boolean import Expression  # NOQA
-from boolean.boolean import BaseElement  # NOQA
-from boolean.boolean import Symbol  # NOQA
-from boolean.boolean import Function  # NOQA
-from boolean.boolean import DualBase  # NOQA
+from boolean.boolean import Expression
+from boolean.boolean import Symbol
 
-from boolean.boolean import FALSE  # NOQA
-from boolean.boolean import TRUE  # NOQA
-from boolean.boolean import AND  # NOQA
-from boolean.boolean import NOT  # NOQA
-from boolean.boolean import OR  # NOQA
+from boolean.boolean import AND
+from boolean.boolean import NOT
+from boolean.boolean import OR
 
-from boolean.boolean import TOKENS  # NOQA
-from boolean.boolean import TOKEN_AND  # NOQA
-from boolean.boolean import TOKEN_OR  # NOQA
-from boolean.boolean import TOKEN_NOT  # NOQA
-from boolean.boolean import TOKEN_LPAR  # NOQA
-from boolean.boolean import TOKEN_RPAR  # NOQA
+from boolean.boolean import TRUE
+from boolean.boolean import FALSE
 
-from boolean.boolean import normalize  # NOQA
-from boolean.boolean import symbols  # NOQA
-from boolean.boolean import parse  # NOQA
+
+from boolean.boolean import TOKEN_TRUE
+from boolean.boolean import TOKEN_FALSE
+from boolean.boolean import TOKEN_SYMBOL
+
+from boolean.boolean import TOKEN_AND
+from boolean.boolean import TOKEN_OR
+from boolean.boolean import TOKEN_NOT
+
+from boolean.boolean import TOKEN_LPAR
+from boolean.boolean import TOKEN_RPAR

--- a/boolean/boolean.py
+++ b/boolean/boolean.py
@@ -1,12 +1,22 @@
 """
-Boolean Algebra.
+Boolean expressions algebra.
 
-This module defines a Boolean Algebra over the set {TRUE, FALSE} with boolean
-variables and the boolean functions AND, OR, NOT. For extensive documentation
-look either into the docs directory or view it online, at
-https://booleanpy.readthedocs.org/en/latest/.
+This module defines a Boolean algebra over the set {TRUE, FALSE} with boolean
+variables called Symbols and the boolean functions AND, OR, NOT. 
 
-Copyright (c) 2009-2010 Sebastian Kraemer, basti.kr@gmail.com
+Some basic logic comparison are supported: Two expressions can be compared for
+equivalence or containment. Furthermore you can simplify an expressions and
+obtain its normal form.
+
+You can create expressions in Python using familiar boolean operators or parse
+expressions from strings. The parsing`easy to extend with your own tokenizer.
+You can also subclass some classes to customize how expressions behave and are
+presented.
+
+For extensive documentation look either into the docs directory or view it
+online, at https://booleanpy.readthedocs.org/en/latest/.
+
+Copyright (c) 2009-2010 Sebastian Kraemer, basti.kr@gmail.com and others
 Released under revised BSD license.
 """
 
@@ -14,7 +24,6 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import itertools
-import collections
 
 try:
     basestring  # Python 2
@@ -22,91 +31,88 @@ except NameError:
     basestring = str  # Python 3
 
 
-# A boolean algebra is defined by its base elements (=domain), its operations
-# (in this case only NOT, AND and OR) and an additional "symbol" type.
-Algebra = collections.namedtuple('Algebra', ('domain', 'operations', 'symbol'))
-
-# Defines the two base elements TRUE and FALSE for the algebra.
-BooleanDomain = collections.namedtuple('BooleanDomain', ('TRUE', 'FALSE'))
-
-# Defines the basic boolean operations NOT, AND and OR.
-BooleanOperations = collections.namedtuple('BooleanOperations', ('NOT', 'AND', 'OR'))
-
 
 class Expression(object):
     """
-    Base class for all boolean expressions.
+    Base class for all boolean expressions, including functions and variable
+    symbols.
     """
-    # Used to store subterms. Can be empty.
-    _args = None
-    # Defines order relation between different classes.
-    _cls_order = None
-    # Stores if an expression is already canonical.
-    _iscanonical = False
-    # Cashes the hash value for an expression. (Expressions are immutable)
-    _hash = None
-    # Stores an object associated to this boolean expression.
-    _obj = None
+    # Defines sort and comparison order relation between different classes.
+    sort_order = None
 
-    # Holds an Algebra tuple which defines the boolean algebra.
-    algebra = None
-
-    def __new__(cls, arg, *args, **kwargs):
-        if isinstance(arg, Expression):
-            return arg
-        if isinstance(arg, basestring):
-            simplify = kwargs.get('simplify', True)
-            return parse(arg, simplify=simplify)
-        elif arg in (0, False):
-            return cls.algebra.domain.FALSE
-        elif arg in (1, True):
-            return cls.algebra.domain.TRUE
-        raise TypeError('Wrong argument for Expression.')
-
-    @property
-    def args(self):
+    def __init__(self, TRUE_class=None, FALSE_class=None,
+                 NOT_class=None, AND_class=None, OR_class=None,
+                 symbol_class=None, tokenizer_fun=None):
         """
-        Return a tuple of all subterms.
-        """
-        return self._args
+        Initialize an expression from another expression or create an empty
+        expression.
+        
+        TRUE_class, FALSE_class, NOT_class, AND_class, OR_class, symbol_class and
+        tokenizer_fun define the boolean algebra domain, operations and symbol and
+        tokenizer callable. They default to the standard corresponding classes and
+        function if not provided.
 
-    @property
-    def obj(self):
+        You can pass subclasses and an alternative tokenizer to customize the
+        behavior of your expressions.
         """
-        Return the associated object of this object.
+        if not getattr(self, 'configured', False):
+            self._configure(TRUE_class, FALSE_class,
+                            NOT_class, AND_class, OR_class,
+                            symbol_class, tokenizer_fun)
+            self.configured = True
 
-        Might be None.
-        """
-        return self._obj
+        # Store arguments aka. subterms of this expressions.
+        # subterms are either literals or expressions.
+        self.args = tuple()
 
+        # True is this is a literal expression such as a Symbol, TRUE or FALSE
+        self.isliteral = False
+
+        # True if this expression has been simplified to in canonical form.
+        self.iscanonical = False
+
+        # Store an associated object: only used in Symbols
+        self.obj = None
+
+    def _configure(self, TRUE_class=None, FALSE_class=None,
+                   NOT_class=None, AND_class=None, OR_class=None,
+                   symbol_class=None, tokenizer_fun=None):
+            """
+            Add provided algebra definitions as attributes to self or use a
+            default configuration.
+            """
+            # default boolean domain
+            self.TRUE = TRUE_class or TRUE
+            self.FALSE = FALSE_class or FALSE
+    
+            # default boolean operations
+            self.NOT = NOT_class or NOT
+            self.AND = AND_class or AND
+            self.OR = OR_class or OR
+    
+            # default class for Symbols
+            self.symbol = symbol_class or Symbol
+    
+            # default tokenizer callable returning tokens
+            self.tokenizer = tokenizer_fun or tokenizer
+    
     @property
     def objects(self):
         """
-        Return a set off all associated objects in this expression.
-
-        Might be an empty set.
+        Return a set off all associated objects with this expression symbols.
+        Include recursively subexpressions objects.
         """
-        s = set() if self.obj is None else set([self.obj])
-        if self.args is not None:
-            for arg in self.args:
-                s |= arg.objects
-        return s
-
-    @property
-    def isliteral(self):
-        """
-        Return True if object is a literal otherwise False.
-        """
-        return False  # This is overridden in all Literals.
+        return set(s.obj for s in self.symbols)
 
     @property
     def literals(self):
         """
-        Return a set of all literals contained in this or any subexpression.
+        Return a set of all literals contained in this expression.
+        Include recursively subexpressions literals.
         """
         if self.isliteral:
             return set((self,))
-        if self.args is None:
+        if not self.args:
             return set()
 
         s = set()
@@ -117,23 +123,25 @@ class Expression(object):
     def literalize(self):
         """
         Return an expression where NOTs are only occurring as literals.
+        Applied recursively to subexpressions.
         """
-        if self.isliteral or self.args is None:
+        if self.isliteral or not self.args:
             return self
         args = tuple(arg.literalize() for arg in self.args)
         if all(arg is self.args[i] for i, arg in enumerate(args)):
             return self
 
-        return self.__class__(*args, simplify=False)
+        return self.__class__(*args)
 
     @property
     def symbols(self):
         """
-        Return a set of all symbols contained in this or any subexpression.
+        Return a set of all symbols contained in this expression.
+        Include recursively subexpressions symbols.
         """
         if isinstance(self, Symbol):
-            return set((self,))
-        if self.args is None:
+            return set([self])
+        if not self.args:
             return set()
 
         s = set()
@@ -141,29 +149,42 @@ class Expression(object):
             s |= arg.symbols
         return s
 
-    def subs(self, subs_dict, simplify=True):
+    def subs(self, substitutions, simplify=True):
         """
-        Return an expression where all subterms equal to a key are substituted.
+        Return an expression where the expression or all subterms equal to a key
+        expression are substituted with the corresponding value expression using
+        a mapping of: {expr->expr to substitute.}
+
+        Return this expression unmodified if nothing could be substituted.
+
+        Note that this can be used to tested for expression containment.
         """
-        for expr, substitution in subs_dict.items():
+        for expr, substitution in substitutions.items():
             if expr == self:
                 return substitution
 
-        expr = self._subs(subs_dict, simplify=simplify)
+        expr = self._subs(substitutions, simplify=simplify)
         return self if expr is None else expr
 
-    def _subs(self, subs_dict, simplify):
+    def _subs(self, substitutions, simplify=True):
+        """
+        Return an expression where all subterms equal to a key expression are
+        substituted by the corresponding value expression using a mapping of:
+        {expr->expr to substitute.}
+        """
         new_args = []
         changed_something = False
         for arg in self.args:
             matched = False
-            for expr, substitution in subs_dict.items():
+            for expr, substitution in substitutions.items():
                 if arg == expr:
                     new_args.append(substitution)
                     changed_something = matched = True
                     break
+
             if not matched:
-                new_arg = None if arg.args is None else arg._subs(subs_dict, simplify)
+                # FIXME: this is not right
+                new_arg = None if not arg.args else arg._subs(substitutions, simplify)
                 if new_arg is None:
                     new_args.append(arg)
                 else:
@@ -171,70 +192,71 @@ class Expression(object):
                     new_args.append(new_arg)
 
         if changed_something:
-            return self.__class__(*new_args, simplify=simplify)
-
-    @property
-    def iscanonical(self):
-        """
-        Return True if the boolean object is in canonical form.
-        """
-        return self._iscanonical
+            newexpr = self.__class__(*new_args)
+            if simplify:
+                newexpr = newexpr.simplify()
+            return newexpr
 
     def simplify(self):
         """
-        Return a possibly simplified, canonical form of the boolean object.
+        Return a new simplified expression in canonical form built from this
+        expression. The simplified expression may be exactly the same as this
+        expression.
+
+        Subclasses override this method to compute actual simplification.
         """
         return self
 
     def __hash__(self):
         """
-        Calculate a hash respecting the structure of the whole expression.
+        Expressions are immutable and hashable. The hash is computed by
+        respecting the structure of the whole expression by mixing the class
+        name hash and the recursive hash of a frozenset of arguments.
 
-        This is done by using as first part the classname and as second
-        the hash of the arguments stored in a frozenset.
-        For more information about equality and hashes, look into the
-        documentation.
-        # TODO: Add entry about hashes into documentation.
+        Note: using a set is OK because expressions with multiple args (AND or
+        OR) behave the same when there are duplicated argument: is there any
+        side effect to use a set of args rather than the original tuple?
+        It uses the facts that:
+        - all operations are commutative and considers different ordering as equal. 
+        - some operation are idempotent, so args can appear more often in one term than in the other.
+
         """
-        # The hash consists of two parts, the hash of the class name and the
-        # hash of the subterms (stored in args). If the object has no subterms,
-        # the id of the object is used instead.
-        # Since all boolean objects are immutable the hash only has to be
-        # computed once.
-        if self._hash is None:
-            if self.args is None:
-                arghash = id(self)
-            else:
-                arghash = hash(frozenset(self.args))
-            self._hash = hash(self.__class__.__name__) ^ arghash
-        return self._hash
+        if not self.args:
+            arghash = id(self)
+        else:
+            arghash = hash(frozenset(map(hash, self.args)))
+        return hash(self.__class__.__name__) ^ arghash
 
     def __eq__(self, other):
         """
         Test if other element is structurally the same as itself.
 
-        This method doesn't try any transformations, so it will return
-        False although terms are mathematically equal. It only uses the fact
-        that all operations are commutative and considers different ordering as
-        equal. Actually also idempotence is used, so args can appear more often
-        in one term than in the other.
+        This method does not make any simplification or transformation, so it will return
+        False although the expression terms may be mathematically equal. 
+        
+        It uses the facts that:
+        - all operations are commutative and considers different ordering as equal. 
+        - some operation are idempotent, so args can appear more often in one term than in the other.
         """
         if self is other:
             return True
+
         if not isinstance(other, self.__class__):
             return NotImplemented
-        if self.args is None or other.args is None:
-            return False
+
+#        if (not self.args) or (not other.args):
+#            return False
+
         return frozenset(self.args) == frozenset(other.args)
 
     def __ne__(self, other):
         return not self == other
 
     def __lt__(self, other):
-        if self._cls_order is not None and other._cls_order is not None:
-            if self._cls_order == other._cls_order:
+        if self.sort_order is not None and other.sort_order is not None:
+            if self.sort_order == other.sort_order:
                 return NotImplemented
-            return self._cls_order < other._cls_order
+            return self.sort_order < other.sort_order
         return NotImplemented
 
     def __gt__(self, other):
@@ -244,164 +266,300 @@ class Expression(object):
         return lt
 
     def __and__(self, other):
-        return self.algebra.operations.AND(self, other)
+        return self.AND(self, other)
 
     __mul__ = __and__
 
     def __invert__(self):
-        return self.algebra.operations.NOT(self)
+        return self.NOT(self)
 
     def __or__(self, other):
-        return self.algebra.operations.OR(self, other)
+        return self.OR(self, other)
 
     __add__ = __or__
 
     def __bool__(self):
-        raise TypeError('Cannot evaluate expression as boolean, please simplify using simplify() or subs()')
+        raise TypeError('Cannot evaluate expression as a Python Boolean.')
 
     __nonzero__ = __bool__
 
+    def _start_operation(self, ast, operation, precedence):
+        """
+        Returns an AST where all operations of lower precedence are finalized.
+        """
+        op_prec = precedence[operation]
+        while True:
+            if ast[1] is None:  # [None, None, x]
+                ast[1] = operation
+                return ast
 
+            prec = precedence[ast[1]]
+            if prec > op_prec:  # op=*, [ast, +, x, y] -> [[ast, +, x], *, y]
+                ast = [ast, operation, ast.pop(-1)]
+                return ast
+
+            if prec == op_prec:  # op=*, [ast, *, x] -> [ast, *, x]
+                return ast
+
+            if ast[0] is None:  # op=+, [None, *, x, y] -> [None, +, x*y]
+                subexp = ast[1](*ast[2:])
+                return [ast[0], operation, subexp]
+
+            else:  # op=+, [[ast, *, x], ~, y] -> [ast, *, x, ~y]
+                ast[0].append(ast[1](*ast[2:]))
+                ast = ast[0]
+
+    def parse(self, expr, simplify=True):
+        """
+        Return a boolean expression parsed from `expr` either a unicode string
+        or tokens iterable.
+    
+        Optionally simplify the expression if `simplify` is True.
+
+        If `expr` is a string, the standard `tokenizer` is used for tokenization and
+        the `self.symbol` Symbol class or subclass is used to create symbol
+        instances from symbol tokens.
+    
+        If `expr` is an iterable, it should contain 3-tuples of: 
+        (token, token_string, position). 
+        token can be a pre-created Symbol instance or a TOKEN id.
+        See the boolean.tokenizer function for details and example.
+        """
+
+        precedence = {self.NOT: 5, self.AND: 10, self.OR: 15, TOKEN_LPAR: 20}
+
+        if isinstance(expr, basestring):
+            tokenized = self.tokenizer(expr)
+        else:
+            tokenized = iter(expr)
+
+        ast = [None, None]
+
+        for token, tokstr, position in tokenized:
+            if token == TOKEN_SYMBOL:
+                ast.append(self.symbol(tokstr))
+            elif isinstance(token, Symbol):
+                ast.append(token)
+
+            elif token == TOKEN_TRUE:
+                ast.append(self.TRUE())
+            elif token == TOKEN_FALSE:
+                ast.append(self.FALSE())
+
+            elif token == TOKEN_NOT:
+                ast = [ast, self.NOT]
+            elif token == TOKEN_AND:
+                ast = self._start_operation(ast, self.AND, precedence)
+            elif token == TOKEN_OR:
+                ast = self._start_operation(ast, self.OR, precedence)
+
+            elif token == TOKEN_LPAR:
+                ast = [ast, TOKEN_LPAR]
+            elif token == TOKEN_RPAR:
+                while True:
+                    if ast[0] is None:
+                        raise TypeError('Bad closing parenthesis at position: %(position)r.' % locals())
+                    if ast[1] is TOKEN_LPAR:
+                        ast[0].append(ast[2])
+                        ast = ast[0]
+                        break
+                    subex = ast[1](*ast[2:])
+                    ast[0].append(subex)
+                    ast = ast[0]
+            else:
+                raise TypeError('Unknown token: %(token)r: %(tokstr)r at position: %(position)r.' % locals())
+
+        while True:
+            if ast[0] is None:
+                if ast[1] is None:
+                    assert len(ast) == 3, 'Invalid boolean expression'
+                    parsed = ast[2]
+                else:
+                    parsed = ast[1](*ast[2:])
+                break
+            else:
+                subex = ast[1](*ast[2:])
+                ast[0].append(subex)
+                ast = ast[0]
+
+        if simplify:
+            return parsed.simplify()
+        return parsed
+
+    # TODO: explain what this means exactly
+    def _rdistributive(self, operation_template):
+        """
+        Recursively flatten this expression for the `operation_template` AND or
+        OR operation instance.
+        """
+        if self.isliteral:
+            return self
+
+        args = (arg._rdistributive(operation_template) for arg in self.args)
+        args = tuple(arg.simplify() for arg in args)
+        if len(args) == 1:
+            return args[0]
+
+        expr = self.__class__(*args)
+
+        dualoperation = operation_template.dual
+        if isinstance(expr, dualoperation):
+            expr = expr.distributive()
+        return expr
+
+    def normalize(self, operation):
+        """
+        Transform an expression into its normal form in the given AND or OR
+        operation.
+    
+        The expression arguments will satisfy these conditions:
+        - operation(*args) == expr (here mathematical equality is meant)
+        - the operation does not occur in any of its arg. 
+        - NOT is only appearing in literals.
+        
+        The operation must be one of the expression configured AND or OR
+        operations or a subclass of it.
+        """
+        # ensure that the operation is not NOT and one of the configured operations
+        assert operation in (self.AND, self.OR,)
+        # Move NOT inwards.
+        expr = self.literalize()
+        # Simplify first, otherwise _rdistributive() may take forever.
+        expr = expr.simplify()
+        operation_template = operation(self.TRUE(), self.FALSE())
+        expr = self._rdistributive(operation_template)
+        # Canonicalize
+        expr = expr.simplify()
+        if isinstance(expr, operation):
+            return expr
+        return operation(*expr.args)
+
+    def build_symbols(self, *args):
+        """
+        Return a tuple of symbols building a new symbol from each argument.
+        """
+        return tuple(map(self.symbol, args))
+
+
+# FIXME: BaseElements should also be literals??
 class BaseElement(Expression):
     """
     Base class for the base elements TRUE and FALSE of the boolean algebra.
     """
-    _cls_order = 0
-    _iscanonical = True
 
-    # The following two attributes define the output of __str__ and __repr__
-    # respectively. They are overwritten in the classes TRUE and FALSE.
-    _str = None
-    _repr = None
+    sort_order = 0
 
-    def __new__(cls, arg=None, simplify=True):
-        if arg is not None:
-            if isinstance(arg, BaseElement):
-                return arg
-            if arg in (0, False):
-                return cls.algebra.domain.FALSE
-            if arg in (1, True):
-                return cls.algebra.domain.TRUE
-            raise TypeError('Bad argument: %s' % arg)
-        if cls is BaseElement:
-            raise TypeError("BaseElement can't be created without argument.")
-        if cls.algebra is None:
-            return object.__new__(cls)
-        if isinstance(cls.algebra.domain.TRUE, cls):
-            return cls.algebra.domain.TRUE
-        if isinstance(cls.algebra.domain.FALSE, cls):
-            return cls.algebra.domain.FALSE
-        raise TypeError('BaseElement can only create objects in the current domain.')
+    def __init__(self):
+        super(BaseElement, self).__init__()
+        self.iscanonical = True
+        # the dual Base Element class for this element.
+        # This is shielded with a property to avoid infinite recursion
+        self._dual_cls = None
 
     @property
     def dual(self):
         """
-        Return the dual Base Element.
-
-        That means TRUE.dual will return FALSE and FALSE.dual will return
-        TRUE.
+        Return the dual Base Element for this element.
+        
+        This means TRUE.dual returns FALSE() and FALSE.dual return TRUE().
         """
-        domain = self.algebra.domain
-        if self is domain.TRUE:
-            return domain.FALSE
-        if self is domain.FALSE:
-            return domain.TRUE
-        raise AttributeError('Class should be TRUE or FALSE but is %s.' % self.cls.__name__)
+        return self._dual_cls()
 
     def __lt__(self, other):
-        cmp = Expression.__lt__(self, other)
-        if cmp is not NotImplemented:
-            return cmp
+        comparator = Expression.__lt__(self, other)
+        if comparator is not NotImplemented:
+            return comparator
         if isinstance(other, BaseElement):
-            return self is self.algebra.domain.FALSE
+            return self == self.FALSE()
         return NotImplemented
 
-    def __str__(self):
-        return self._str
+    def __hash__(self):
+        return hash(bool(self))
 
-    def __repr__(self):
-        return self._repr
+    def __eq__(self, other):
+        if self is other or isinstance(other, self.__class__):
+            return True
+
+        return super(BaseElement, self).__eq__(other)
+
+    __nonzero__ = __bool__ = lambda s: None
+
+    def pretty(self, indent=0, debug=False):
+        """
+        Return a pretty formatted representation of self.
+        """
+        return (' ' * indent) + repr(self)
 
 
-class _TRUE(BaseElement):
+class TRUE(BaseElement):
     """
     Boolean base element TRUE.
 
-    This is one of the two elements of the boolean algebra.
+    You can subclass to define alternative string representation.
     """
-    _str = '1'
-    _repr = 'TRUE'
+
+    def __init__(self, *args, **kwargs):
+        super(TRUE, self).__init__()
+        self._dual_cls = self.FALSE
+
+    def __str__(self):
+        return '1'
+
+    def __repr__(self):
+        return 'TRUE()'
 
     __nonzero__ = __bool__ = lambda s: True
 
 
-class _FALSE(BaseElement):
+class FALSE(BaseElement):
     """
     Boolean base element FALSE.
 
-    This is one of the two elements of the boolean algebra.
+    You can subclass to define alternative string representation.
     """
-    _str = '0'
-    _repr = 'FALSE'
+
+    def __init__(self, *args, **kwargs):
+        super(FALSE, self).__init__()
+        self._dual_cls = self.TRUE
+
+    def __str__(self):
+        return '0'
+
+    def __repr__(self):
+        return 'FALSE()'
 
     __nonzero__ = __bool__ = lambda s: False
-
-
-# Initialize two singletons which will be used as base elements for the
-# default boolean algebra.
-TRUE = _TRUE()
-FALSE = _FALSE()
 
 
 class Symbol(Expression):
     """
     Boolean variable.
-
-    Symbols (also called boolean variables) can only take on the values TRUE
-    or FALSE. They can hold an object that will be used to determine equality.
-    These are called "named symbols". Alternatively it's possible to create
-    symbols without any argument (or the argument None). That will result in
-    "anonymous symbols", which will always be unequal to any other symbol but
-    themselves.
+    
+    A symbol can hold an object used to determine equality.
     """
-    _cls_order = 5
-    _iscanonical = True
+    # FIXME: this statement is weird: Symbols do nor have a value assigned??
+    """
+    Symbols (also called boolean variables) can only take on the values TRUE
+    or FALSE. 
+    """
 
-    _obj = None
+    sort_order = 5
 
-    def __new__(cls, *args, **kwargs):
-        return object.__new__(cls)
-
-    def __init__(self, obj=None, simplify=True):
-        self._obj = obj
-
-    @property
-    def obj(self):
-        """
-        Return the object associated with this symbol.
-        """
-        return self._obj
-
-    @property
-    def isliteral(self):
-        """
-        Return True if object is a literal otherwise False.
-        """
-        return True
+    def __init__(self, obj):
+        super(Symbol, self).__init__()
+        self.obj = obj
+        self.iscanonical = True
+        self.isliteral = True
 
     def __hash__(self):
         """
         Calculate a hash considering eventually associated objects.
         """
-        if self._hash is not None:
-            return self._hash  # Return cached hash.
-        else:
-            if self.obj is None:  # Anonymous symbol.
-                myhash = id(self)
-            else:  # Hash of associated object.
-                myhash = hash(self.obj)
-            self._hash = myhash
-            return myhash
+        if self.obj is None:  # Anonymous symbol.
+            myhash = id(self)
+        else:  # Hash of associated object.
+            myhash = hash(self.obj)
+        return myhash
 
     def __eq__(self, other):
         """
@@ -411,105 +569,132 @@ class Symbol(Expression):
             return True
         if not isinstance(other, self.__class__):
             return NotImplemented
-        if self.obj is None or other.obj is None:
-            return False
         return self.obj == other.obj
 
     def __lt__(self, other):
-        cmp = Expression.__lt__(self, other)
-        if cmp is not NotImplemented:
-            return cmp
+        comparator = Expression.__lt__(self, other)
+        if comparator is not NotImplemented:
+            return comparator
         if isinstance(other, Symbol):
-            if self.obj is None:
-                if other.obj is None:
-                    return hash(self) < hash(other)  # 2 anonymous symbols.
-                return False  # Anonymous-Symbol < Named-Symbol.
-            if other.obj is None:
-                return True  # Named-Symbol < Anonymous-Symbol.
-            return self.obj < other.obj  # 2 named symbols.
+            return self.obj < other.obj
         return NotImplemented
 
     def __str__(self):
-        if self.obj is None:
-            return 'S<%s>' % hash(self)
         return str(self.obj)
 
     def __repr__(self):
-        if self.obj is not None:
-            obj = "'%s'" % self.obj if isinstance(self.obj, basestring) else repr(self.obj)
-        else:
-            obj = hash(self)
+        obj = "'%s'" % self.obj if isinstance(self.obj, basestring) else repr(self.obj)
         return '%s(%s)' % (self.__class__.__name__, obj)
+
+    def pretty(self, indent=0, debug=False):
+        """
+        Return a pretty formatted representation of self.
+        """
+        debug_details = ''
+        if debug:
+            debug_details += '<isliteral=%r, iscanonical=%r>' % (self.isliteral, self.iscanonical)
+
+        obj = "'%s'" % self.obj if isinstance(self.obj, basestring) else repr(self.obj)
+        return (' ' * indent) + ('%s(%s%s)' % (self.__class__.__name__, debug_details, obj))
 
 
 class Function(Expression):
     """
     Boolean function.
 
-    A boolean function takes n boolean expressions as arguments (n is called
-    the order of the function) and maps them to one of the base elements.
-    Typical examples for implemented functions are AND and OR.
+    A boolean function takes n (one or more) boolean expressions as arguments
+    where n is called the order of the function and maps them to one of the base
+    elements TRUE or FALSE. Implemented functions are AND, OR and NOT.
     """
     # Specifies how many arguments a function takes. the first number gives a
-    # lower limit, the second an upper limit.
+    # lower limit/minimum, the second an upper limit/maximum number of args.
     order = (2, float('inf'))
 
-    # Specifies an infix notation of an operator for printing.
-    operator = None
+    def __init__(self, *args):
+        super(Function, self).__init__()
 
-    def __new__(cls, *args, **kwargs):
-        simplify = kwargs.pop('simplify', True)
-        if kwargs:
-            raise TypeError('Got an unexpected keyword argument %r' % kwargs.keys()[0])
-        length = len(args)
-        order = cls.order
-        if simplify:
-            return cls(*args, simplify=False).simplify()
-        if order[0] > length:
-            raise TypeError('Too few arguments. Got %s, but need at least %s.' % (length, order[0]))
-        if order[1] < length:
-            raise TypeError('Too many arguments. Got %s, but need at most %s.' % (length, order[1]))
-        return object.__new__(cls)
+        minimum, maximum = self.order
+        args_length = len(args)
 
-    def __init__(self, *args, **kwargs):
-        # If a function in the __new__ method is evaluated the __init__ method
-        # will be called twice. First with the simplified then with original
-        # arguments. The following 'if' prevents that the simplified ones are
-        # overwritten.
-        kwargs.pop('simplify', True)
-        if kwargs:
-            raise TypeError('Got an unexpected keyword argument %r' % kwargs.keys()[0])
-        if self._args:
-            return
-        _args = [None] * len(args)
+        if minimum > args_length:
+            raise TypeError('Too few arguments. Got %(args_length)r, but need at least %(minimum)r.' % locals())
+        if maximum < args_length:
+            raise TypeError('Too many arguments. Got %(args_length)r, but need at most %(maximum)r.' % locals())
+
+        # Specifies an infix notation of an operator for printing such as | or &.
+        self.operator = None
+
         # Make sure all arguments are boolean expressions.
-        for i, arg in enumerate(args):
-            if isinstance(arg, Expression):
-                _args[i] = arg
-            elif isinstance(arg, basestring):
-                _args[i] = parse(arg)
-            elif arg in (0, False):
-                _args[i] = FALSE
-            elif arg in (1, True):
-                _args[i] = TRUE
-            else:
-                raise TypeError('Bad argument: %s' % arg)
-        self._args = tuple(_args)
+        assert all(isinstance(arg, Expression) for arg in args), 'Bad arguments: all arguments must be an Expression: %r' % (args,)
+        self.args = tuple(args)
 
     def __str__(self):
         args = self.args
         if self.operator is None:
-            return '%s(%s)' % (self.__class__.__name__, ', '.join(str(arg) for arg in args))
-        elif len(args) == 1:
+            raise TypeError('self.operator cannot be None')
+
+        if len(args) == 1:
             if self.isliteral:
                 return '%s%s' % (self.operator, args[0])
             return '%s(%s)' % (self.operator, args[0])
 
-        args = ('%s' % arg if arg.isliteral else '(%s)' % arg for arg in args)
-        return self.operator.join(args)
+        args_str = []
+        for arg in args:
+            if arg.isliteral:
+                args_str.append(str(arg))
+            else:
+                args_str.append('(%s)' % arg)
+
+        return self.operator.join(args_str)
 
     def __repr__(self):
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(repr(arg) for arg in self.args))
+        return '%s(%s)' % (self.__class__.__name__, ', '.join(map(repr, self.args)))
+
+    def pretty(self, indent=0, debug=False):
+        """
+        Return a pretty formatted representation of self as an indented tree.
+
+        If debug is True, also prints debug information for each expression term.
+
+        For example:
+        >>> print Expression().parse(u'not a and not b and not (a and ba and c) and c or c', simplify=False).pretty()
+        OR(
+          AND(
+            NOT(Symbol('a')),
+            NOT(Symbol('b')),
+            NOT(
+              AND(
+                Symbol('a'),
+                Symbol('ba'),
+                Symbol('c')
+              )
+            ),
+            Symbol('c')
+          ),
+          Symbol('c')
+        )
+        """
+        debug_details = ''
+        if debug:
+            debug_details += '<isliteral=%r, iscanonical=%r' % (self.isliteral, self.iscanonical)
+            identity = getattr(self, 'identity', None)
+            if identity is not None:
+                debug_details += ', identity=%r' % (identity)
+
+            annihilator = getattr(self, 'annihilator', None)
+            if annihilator is not None:
+                debug_details += ', annihilator=%r' % (annihilator)
+
+            dual = getattr(self, 'dual', None)
+            if dual is not None:
+                debug_details += ', dual=%r' % (dual)
+            debug_details += '>'
+        cls = self.__class__.__name__
+        args = [a.pretty(indent=indent + 2, debug=debug) for a in self.args]
+        pfargs = ',\n'.join(args)
+        cur_indent = ' ' * indent
+        new_line = '' if self.isliteral else '\n'
+        return '{cur_indent}{cls}({debug_details}{new_line}{pfargs}\n{cur_indent})'.format(**locals())
 
 
 class NOT(Function):
@@ -518,19 +703,24 @@ class NOT(Function):
 
     The NOT operation takes exactly one argument. If this argument is a Symbol
     the resulting expression is also called a literal.
+
     The operator "~" can be used as abbreviation for NOT, e.g. instead of
     NOT(x) one can write ~x (where x is some boolean expression). Also for
     printing "~" is used for better readability.
+    
+    You can subclass to define alternative string representation.
+    For example::
+    >>> class NOT2(NOT):
+        def __init__(self, *args):
+            super(NOT2, self).__init__(*args)
+            self.operator = '!'
     """
     order = (1, 1)
-    operator = '~'
 
-    @property
-    def isliteral(self):
-        """
-        Return True if object is a literal otherwise False.
-        """
-        return isinstance(self.args[0], Symbol)
+    def __init__(self, *args):
+        super(NOT, self).__init__(*args)
+        self.isliteral = self.args[0].isliteral
+        self.operator = '~'
 
     def literalize(self):
         """
@@ -543,21 +733,23 @@ class NOT(Function):
 
     def simplify(self):
         """
-        Return a simplified term in canonical form.
+        Return a simplified expr in canonical form.
 
         This means double negations are canceled out and all contained boolean
         objects are in their canonical form.
         """
         if self.iscanonical:
             return self
-        term = self.cancel()
-        if not isinstance(term, self.__class__):
-            return term.simplify()
-        if term.args[0] in self.algebra.domain:
-            return term.args[0].dual
 
-        expr = self.__class__(term.args[0].simplify(), simplify=False)
-        expr._iscanonical = True
+        expr = self.cancel()
+        if not isinstance(expr, self.__class__):
+            return expr.simplify()
+
+        if expr.args[0] in (self.TRUE(), self.FALSE()):
+            return expr.args[0].dual
+
+        expr = self.__class__(expr.args[0].simplify())
+        expr.iscanonical = True
         return expr
 
     def cancel(self):
@@ -566,29 +758,43 @@ class NOT(Function):
 
         Returns the simplified expression.
         """
-        term = self
+        expr = self
         while True:
-            arg = term.args[0]
+            arg = expr.args[0]
             if not isinstance(arg, self.__class__):
-                return term
-            term = arg.args[0]
-            if not isinstance(term, self.__class__):
-                return term
+                return expr
+            expr = arg.args[0]
+            if not isinstance(expr, self.__class__):
+                return expr
 
     def demorgan(self):
         """
-        Return a term where the NOT function is moved inward.
+        Return a expr where the NOT function is moved inward.
 
         This is achieved by canceling double NOTs and using De Morgan laws.
         """
-        term = self.cancel()
-        if term.isliteral or not isinstance(term.args[0], self.algebra.operations):
-            return term
-        op = term.args[0]
-        return op.dual(*tuple(self.__class__(arg, simplify=False).cancel() for arg in op.args), simplify=False)
+        expr = self.cancel()
+        if expr.isliteral or not isinstance(expr.args[0], (self.NOT, self.AND, self.OR)):
+            return expr
+        op = expr.args[0]
+        return op.dual(*(self.__class__(arg).cancel() for arg in op.args))
 
     def __lt__(self, other):
         return self.args[0] < other
+
+    def pretty(self, indent=1, debug=False):
+        """
+        Return a pretty formatted representation of self.
+        Include additional debug details if `debug` is True.
+        """
+        debug_details = ''
+        if debug:
+            debug_details += '<isliteral=%r, iscanonical=%r>' % (self.isliteral, self.iscanonical)
+        if self.isliteral:
+            pretty_literal = self.args[0].pretty(indent=0, debug=debug)
+            return (' ' * indent) + '%s(%s%s)' % (self.__class__.__name__, debug_details, pretty_literal)
+        else:
+            return super(NOT, self).pretty(indent=indent, debug=debug)
 
 
 class DualBase(Function):
@@ -599,114 +805,96 @@ class DualBase(Function):
     and OR. Both operations take 2 or more arguments and can be created using
     "+" for OR and "*" for AND.
     """
-    # Specifies the identity element for the specific operation. (TRUE for
-    # AND and FALSE for OR).
-    _identity = None
 
-    @property
-    def identity(self):
-        """
-        Return the identity element for this function.
+    def __init__(self, *args):
+        super(DualBase, self).__init__(*args)
 
-        This will be TRUE for the AND operation and FALSE for the OR operation.
-        """
-        return BaseElement(self._identity)
+        # identity element for the specific operation.
+        # This will be TRUE for the AND operation and FALSE for the OR operation.
+        self.identity = None
 
-    @property
-    def annihilator(self):
-        """
-        Return the annihilator element for this function.
+        # annihilator element for this function.
+        # This will be FALSE for the AND operation and TRUE for the OR operation.
+        self.annihilator = None
 
-        This will be FALSE for the AND operation and TRUE for the OR operation.
-        """
-        return BaseElement(not self._identity)
-
-    @property
-    def dual(self):
-        """
-        Return the dual class of this function.
-
-        This means OR.getdual() returns AND and AND.getdual() returns OR.
-        This is just a convenient shortcut for getdual()
-        """
-        return self.getdual()
-
-    @classmethod
-    def getdual(cls):
-        """
-        Return the dual class of this function.
-
-        This means OR.getdual() returns AND and AND.getdual() returns OR.
-        """
-        ops = cls.algebra.operations
-        if issubclass(cls, ops.OR):
-            return ops.AND
-        if issubclass(cls, ops.AND):
-            return ops.OR
-        raise AttributeError("Class must be in algebra.operations.")
+        # dual class of this function.
+        # This means OR.dual returns AND and AND.dual returns OR.
+        self.dual = None
 
     def __contains__(self, expr):
         """
-        Tests if expr is a subterm.
+        Test if expr is a subterm of this expression.
         """
         if expr in self.args:
             return True
+
         if isinstance(expr, self.__class__):
             if all(arg in self.args for arg in expr.args):
                 return True
 
     def simplify(self):
         """
-        Return a simplified expression in canonical form.
+        Return a new simplified expression in canonical form from this
+        expression.
 
-        For simplification of AND and OR following rules are used
+        For simplification of AND and OR fthe ollowing rules are used
         recursively bottom up:
-         - Idempotence
-         - Commutativity (output is always sorted)
-         - Associativity (output doesn't contain same operations nested)
+         - Associativity (output does not contain same operations nested)
          - Annihilation
+         - Idempotence
          - Identity
          - Complementation
+         - Elimination
          - Absorption
+         - Commutativity (output is always sorted)
 
         Other boolean objects are also in their canonical form.
         """
         # TODO: Refactor DualBase.simplify into different "sub-evals".
+
         # If self is already canonical do nothing.
         if self.iscanonical:
             return self
-        ops = self.algebra.operations
+
         # Otherwise bring arguments into canonical form.
-        args = tuple(arg.simplify() for arg in self.args)
-        # Create new instance of own class with canonical args. "simplify" has to
-        # be set False - otherwise infinite recursion!
+        args = [arg.simplify() for arg in self.args]
+
+        # Create new instance of own class with canonical args.
         # TODO: Only create new class if some args changed.
-        term = self.__class__(*args, simplify=False)
-        # Literalize before doing anything, this also applies De Mogan's Law
-        term = term.literalize()
+        expr = self.__class__(*args)
+
+        # Literalize before doing anything, this also applies De Morgan's Law
+        expr = expr.literalize()
+
         # Associativity:
         #     (A * B) * C = A * (B * C) = A * B * C
         #     (A + B) + C = A + (B + C) = A + B + C
-        term = term.flatten()
+        expr = expr.flatten()
+
         # Annihilation: A * 0 = 0, A + 1 = 1
-        if self.annihilator in term.args:
+        if self.annihilator in expr.args:
             return self.annihilator
+
         # Idempotence: A * A = A, A + A = A
+        # this boils down to removing duplicates
         args = []
-        for arg in term.args:
+        for arg in expr.args:
             if arg not in args:
                 args.append(arg)
         if len(args) == 1:
             return args[0]
+
         # Identity: A * 1 = A, A + 0 = A
         if self.identity in args:
             args.remove(self.identity)
             if len(args) == 1:
                 return args[0]
+
         # Complementation: A * ~A = 0, A + ~A = 1
         for arg in args:
-            if ops.NOT(arg) in args:
+            if self.NOT(arg) in args:
                 return self.annihilator
+
         # Elimination: (A * B) + (A * ~B) = A, (A + B) * (A + ~B) = A
         i = 0
         while i < len(args) - 1:
@@ -720,12 +908,14 @@ class DualBase(Function):
                 if not isinstance(aj, self.dual) or len(ai.args) != len(aj.args):
                     j += 1
                     continue
+
                 # Find terms where only one arg is different.
                 negated = None
                 for arg in ai.args:
+                    # FIXME: what does this pass Do?
                     if arg in aj.args:
                         pass
-                    elif ops.NOT(arg, simplify=False).cancel() in aj.args:
+                    elif self.NOT(arg).cancel() in aj.args:
                         if negated is None:
                             negated = arg
                         else:
@@ -734,7 +924,8 @@ class DualBase(Function):
                     else:
                         negated = None
                         break
-                # If the different arg is a negation simplify the term.
+
+                # If the different arg is a negation simplify the expr.
                 if negated is not None:
                     # Cancel out one of the two terms.
                     del args[j]
@@ -743,30 +934,34 @@ class DualBase(Function):
                     if len(aiargs) == 1:
                         args[i] = aiargs[0]
                     else:
-                        args[i] = self.dual(*aiargs, simplify=False)
+                        args[i] = self.dual(*aiargs)
+
                     if len(args) == 1:
                         return args[0]
                     else:
-                        # Now the other simplifications have to be
-                        # redone.
-                        return self.__class__(*args, simplify=True)
+                        # Now the other simplifications have to be redone.
+                        return self.__class__(*args).simplify()
                 j += 1
             i += 1
+
         # Absorption: A * (A + B) = A, A + (A * B) = A
         # Negative absorption: A * (~A + B) = A * B, A + (~A * B) = A + B
         args = self.absorb(args)
         if len(args) == 1:
             return args[0]
+
         # Commutativity: A * B = B * A, A + B = B + A
         args.sort()
+
         # Create new (now canonical) expression.
-        term = self.__class__(*args, simplify=False)
-        term._iscanonical = True
-        return term
+        expr = self.__class__(*args)
+        expr.iscanonical = True
+        return expr
 
     def flatten(self):
         """
-        Return a term where nested terms are flattened as far as possible.
+        Return a new expression where nested terms of this expression are
+        flattened as far as possible.
 
         E.g. A * (B * C) becomes A * B * C.
         """
@@ -778,13 +973,22 @@ class DualBase(Function):
                 i += len(arg.args)
             else:
                 i += 1
-        return self.__class__(*args, simplify=False)
 
-    def absorb(self, useargs=None):
-        # Absorption: A * (A + B) = A, A + (A * B) = A
-        # Negative absorption: A * (~A + B) = A * B, A + (~A * B) = A + B
-        args = list(self.args) if useargs is None else list(useargs)
-        ops = self.algebra.operations
+        return self.__class__(*args)
+
+    def absorb(self, args):
+        """
+        Given an `args` sequence of expressions, return a new list of expression
+        applying absorption and negative absorption.
+        
+        See https://en.wikipedia.org/wiki/Absorption_law
+
+        Absorption: A * (A + B) = A, A + (A * B) = A
+        Negative absorption: A * (~A + B) = A * B, A + (~A * B) = A + B
+        """
+        args = list(args)
+        if not args:
+            args = list(self.args)
         i = 0
         while i < len(args):
             absorber = args[i]
@@ -797,16 +1001,18 @@ class DualBase(Function):
                 if not isinstance(target, self.dual):
                     j += 1
                     continue
+
                 # Absorption
                 if absorber in target:
                     del args[j]
                     if j < i:
                         i -= 1
                     continue
+
                 # Negative absorption
-                neg_absorber = ops.NOT(absorber, simplify=False).cancel()
+                neg_absorber = self.NOT(absorber).cancel()
                 if neg_absorber in target:
-                    b = target.remove(neg_absorber, simplify=False)
+                    b = target.subtract(neg_absorber, simplify=False)
                     if b is None:
                         del args[j]
                         if j < i:
@@ -816,10 +1022,11 @@ class DualBase(Function):
                         args[j] = b
                         j += 1
                         continue
+
                 if isinstance(absorber, self.dual):
                     remove = None
                     for arg in absorber.args:
-                        narg = ops.NOT(arg, simplify=False).cancel()
+                        narg = self.NOT(arg).cancel()
                         if arg in target.args:
                             pass
                         elif narg in target.args:
@@ -832,16 +1039,17 @@ class DualBase(Function):
                             remove = None
                             break
                     if remove is not None:
-                        args[j] = target.remove(remove)
+                        args[j] = target.subtract(remove, simplify=True)
                 j += 1
             i += 1
-        if useargs:
-            return args
-        if len(args) == 1:
-            return args[0]
-        return self.__class__(*args, simplify=False)
 
-    def remove(self, expr, simplify=True):
+        return args
+
+    def subtract(self, expr, simplify):
+        """
+        Return a new expression where the `expr` expression has been removed
+        from this expression if it exists.
+        """
         args = self.args
         if expr in self.args:
             args = list(self.args)
@@ -851,11 +1059,13 @@ class DualBase(Function):
                 args = tuple(arg for arg in self.args if arg not in expr)
         if len(args) == 0:
             return None
-        elif len(args) == 1:
+        if len(args) == 1:
             return args[0]
-        else:
-            return self.__class__(*args, simplify=simplify)
-        return args
+
+        newexpr = self.__class__(*args)
+        if simplify:
+            newexpr = newexpr.simplify()
+        return newexpr
 
     def distributive(self):
         """
@@ -872,26 +1082,31 @@ class DualBase(Function):
                 args[i] = arg.args
             else:
                 args[i] = (arg,)
+
         prod = itertools.product(*args)
-        args = tuple(self.__class__(*arg) for arg in prod)
+        args = tuple(self.__class__(*arg).simplify() for arg in prod)
+
         if len(args) == 1:
             return args[0]
         else:
-            return dual(*args, simplify=False)
+            return dual(*args)
 
     def __lt__(self, other):
-        cmp = Expression.__lt__(self, other)
-        if cmp is not NotImplemented:
-            return cmp
+        comparator = Expression.__lt__(self, other)
+        if comparator is not NotImplemented:
+            return comparator
+
         if isinstance(other, self.__class__):
             lenself = len(self.args)
             lenother = len(other.args)
             for i in range(min(lenself, lenother)):
                 if self.args[i] == other.args[i]:
                     continue
-                cmp = self.args[i] < other.args[i]
-                if cmp is not NotImplemented:
-                    return cmp
+
+                comparator = self.args[i] < other.args[i]
+                if comparator is not NotImplemented:
+                    return comparator
+
             if lenself != lenother:
                 return lenself < lenother
         return NotImplemented
@@ -899,266 +1114,146 @@ class DualBase(Function):
 
 class AND(DualBase):
     """
-    Boolean AND operation.
+    Boolean AND operation, taking 2 or more arguments. 
+    
+    It can also be created by using "*" between two boolean expressions.
 
-    The AND operation takes 2 or more arguments and can also be created by
-    using "*" between two boolean expressions.
+    You can subclass to define alternative string representation.
+    For example::
+    >>> class AND2(AND):
+        def __init__(self, *args):
+            super(AND2, self).__init__(*args)
+            self.operator = 'AND'
     """
-    _cls_order = 10
-    _identity = True
-    operator = '*'
+
+    sort_order = 10
+
+    def __init__(self, *args):
+        super(AND, self).__init__(*args)
+        self.identity = self.TRUE()
+        self.annihilator = self.FALSE()
+        self.dual = self.OR
+        self.operator = '*'
 
 
 class OR(DualBase):
     """
-    Boolean OR operation.
+    Boolean OR operation, taking 2 or more arguments
+    
+    It can also be created by using "+" between two boolean expressions.
 
-    The OR operation takes 2 or more arguments and can also be created by
-    using "+" between two boolean expressions.
-    """
-    _cls_order = 25
-    _identity = False
-    operator = '+'
-
-
-# Create a default algebra.
-DOMAIN = BooleanDomain(TRUE=TRUE, FALSE=FALSE)
-OPERATIONS = BooleanOperations(NOT=NOT, AND=AND, OR=OR)
-ALGEBRA = Algebra(DOMAIN, OPERATIONS, Symbol)
-Expression.algebra = ALGEBRA
-
-
-def rdistributive(operation, expr):
-    "Totally flatten everything."
-    if expr.isliteral:
-        return expr
-    args = tuple(rdistributive(operation, arg).simplify() for arg in expr.args)
-    if len(args) == 1:
-        return args[0]
-    expr = expr.__class__(*args)
-    dualoperation = operation.getdual()
-    if isinstance(expr, dualoperation):
-        expr = expr.distributive()
-    return expr
-
-
-def normalize(operation, expr):
-    """
-    Transform a expression into its normal form in the given operation.
-
-    Returns a tuple of arguments that will satisfy the condition
-    operation(*args) == expr (here mathematical equality is meant) and
-    the operation doesn't occur in any arg. Also NOT is only appearing
-    in literals.
+    You can subclass to define alternative string representation.
+    For example::
+    >>> class OR2(OR):
+        def __init__(self, *args):
+            super(OR2, self).__init__(*args)
+            self.operator = 'OR'
     """
 
-    # Move NOT inwards.
-    expr = expr.literalize()
-    # Simplify as much as possible, otherwise rdistributive() may take
-    # forever.
-    expr = expr.simplify()
-    expr = rdistributive(operation, expr)
-    # Canonicalize
-    expr = expr.simplify()
-    if isinstance(expr, operation):
-        args = expr.args
-    else:
-        args = (expr,)
-    return args
+    sort_order = 25
+
+    def __init__(self, *args):
+        super(OR, self).__init__(*args)
+        self.identity = self.FALSE()
+        self.annihilator = self.TRUE()
+        self.dual = self.AND
+        self.operator = '+'
 
 
-def symbols(*args):
-    """
-    Returns a Symbol for every argument given.
-    """
-    Symbol = ALGEBRA.symbol
-    return tuple(Symbol(arg) for arg in args)
-
-
-# Token objects for standard operators and parens
+# Token types for standard operators and parens
 TOKEN_AND = 1
 TOKEN_OR = 2
 TOKEN_NOT = 3
 TOKEN_LPAR = 4
 TOKEN_RPAR = 5
-
-# mapping of lowercase token strings to a token object instance for standard
-# operators, parens and common true or false symbols
-TOKENS = {
-    '*': TOKEN_AND,
-    '&': TOKEN_AND,
-    'and': TOKEN_AND,
-    '|': TOKEN_OR,
-    '+': TOKEN_OR,
-    'or': TOKEN_OR,
-    '~': TOKEN_NOT,
-    '!': TOKEN_NOT,
-    'not': TOKEN_NOT,
-    '(': TOKEN_LPAR,
-    '[': TOKEN_LPAR,
-    ']': TOKEN_RPAR,
-    ')': TOKEN_RPAR,
-    'true': TRUE,
-    '1': TRUE,
-    'false': FALSE,
-    '0': FALSE,
-    'none': FALSE,
-}
+TOKEN_TRUE = 6
+TOKEN_FALSE = 7
+TOKEN_SYMBOL = 8
 
 
-def tokenizer(expr, symbol_class=Symbol):
+def tokenizer(expr):
     """
-    A tokenizer is a callable accepting a unicode string and returning an
-    iterable of 3-tuple describing each token.
+    A tokenizer is a callable accepting a single unicode string as an argument
+    and returning an iterable of 3-tuple describing each token.
 
     This tuple must contain (token, token string, position):
-    - token: either a Symbol or BaseElement instance or one of TOKENS values.
-    - token string: the original token string.
+    - token: either a Symbol instance or one of TOKEN_* token types..
+    - token string: the original token unicode string.
     - position: some simple object describing the starting position of the
-      original token string in the `expr` string. It could be an int for a
+      original token string in the `expr` string. It can be an int for a
       character offset, or a tuple of starting (row/line, column).
-    Note that the position is used only for error reporting
-    and can be None or empty.
+
+    The token position is used only for error reporting and can be None or
+    empty.
 
     Raise TypeError on errors.
 
-    In this tokenizer, the `expr` string can span multiple lines. Whitespace is
-    not-significant. The position is a tuple of (start line, start column).
-
-    A symbol instance is created for valid Python identifiers, dotted names and
-    names with colons.
-    
-    These are not identifiers:
-    - quoted strings.
-    - any punctuation which is not an operation.
-
-    Recognized operator are (in any upper/lower case combinations):
-    - for and:  '*', '&', 'and'
-    - for or: '+', '|', 'or'
-    - for not: '~', '!', 'not'
-
-    Recognized special symbols are (in any upper/lower case combinations):
-    - True symbols: 1 and True
-    - False symbols: 0, False and None
-
     You can use this tokenizer as a base to create specialized custom tokenizers
-    for your algebra. See also examples in tests.
+    for your algebra. See also the tests for other examples of alternative
+    tokenizers.
+
+    This tokenizer has these characteristics:
+    - The `expr` string can span multiple lines,
+    - Whitespace is not significant. 
+    - The returned position is the starting character offset of a token.
+
+    - A TOKEN_SYMBOL is returned for valid identifiers.
+        These are identifiers:
+        - Python identifiers.
+        - dotted names : foo.bar consist of one token.
+        - names with colons: foo:bar consist of one token.
+        These are not identifiers:
+        - quoted strings.
+        - any punctuation which is not an operation
+
+    - Recognized operators are (in any upper/lower case combinations):
+        - for and:  '*', '&', 'and'
+        - for or: '+', '|', 'or'
+        - for not: '~', '!', 'not'
+
+    - Recognized special symbols are (in any upper/lower case combinations):
+        - True symbols: 1 and True
+        - False symbols: 0, False and None
     """
     if not isinstance(expr, basestring):
         raise TypeError('expr must be string but it is %s.' % type(expr))
 
+    # mapping of lowercase token strings to a token ids for the standard operators,
+    # parens and common true or false symbols, as used in the default tokenizer
+    # implementation.
+    _TOKENS = {
+        '*': TOKEN_AND, '&': TOKEN_AND, 'and': TOKEN_AND,
+        '+': TOKEN_OR, '|': TOKEN_OR, 'or': TOKEN_OR,
+        '~': TOKEN_NOT, '!': TOKEN_NOT, 'not': TOKEN_NOT,
+        '(': TOKEN_LPAR, ')': TOKEN_RPAR,
+        '[': TOKEN_LPAR, ']': TOKEN_RPAR,
+        'true': TOKEN_TRUE, '1': TOKEN_TRUE,
+        'false': TOKEN_FALSE, '0': TOKEN_FALSE, 'none': TOKEN_FALSE
+    }
+
     length = len(expr)
-    offset = 0
-    while offset < length:
-        tok = expr[offset]
+    position = 0
+    while position < length:
+        tok = expr[position]
 
         sym = tok.isalpha() or tok == '_'
         if sym:
-            offset += 1
-            while offset < length:
-                char = expr[offset]
+            position += 1
+            while position < length:
+                char = expr[position]
                 if char.isalnum() or char in ('.', ':', '_'):
-                    offset += 1
+                    position += 1
                     tok += char
                 else:
                     break
-            offset -= 1
+            position -= 1
 
         try:
-            yield TOKENS[tok.lower()], tok, offset
+            yield _TOKENS[tok.lower()], tok, position
         except KeyError:
             if sym:
-                yield symbol_class(tok), tok, offset
+                yield TOKEN_SYMBOL, tok, position
             elif tok not in (' ', '\t', '\r', '\n'):
                 raise TypeError('Unknown token: %(tok)r at position: %(position)r' % locals())
 
-        offset += 1
-
-
-PRECEDENCE = {
-    NOT: 5,
-    AND: 10,
-    OR: 15,
-    TOKEN_LPAR: 20,
-}
-
-
-def parse(expr, simplify=True, symbol_class=Symbol):
-    """
-    Return a boolean expression parsed from the given `expr` string or iterable
-    of tokens.
-
-    Optionally simplify the expression if `simplify` is True.
-
-    If `expr` is a string, the standard `tokenizer` is used for tokenization and
-    the given `symbol_class` Symbol class or subclass is used to create symbol
-    instances from symbol token strings.
-
-    If `expr` is an iterable, it should contain 3-tuples of: (token, token
-    string, position). See the boolean.tokenizer function for details and example.
-    """
-
-    def start_operation(ast, operation):
-        """
-        Returns an AST where all operations of lower precedence are finalized.
-        """
-        op_prec = PRECEDENCE[operation]
-        while True:
-            if ast[1] is None:  # [None, None, x]
-                ast[1] = operation
-                return ast
-            prec = PRECEDENCE[ast[1]]
-            if prec > op_prec:  # op=*, [ast, +, x, y] -> [[ast, +, x], *, y]
-                ast = [ast, operation, ast.pop(-1)]
-                return ast
-            if prec == op_prec:  # op=*, [ast, *, x] -> [ast, *, x]
-                return ast
-            if ast[0] is None:  # op=+, [None, *, x, y] -> [None, +, x*y]
-                return [ast[0], operation, ast[1](*ast[2:], simplify=simplify)]
-            else:  # op=+, [[ast, *, x], ~, y] -> [ast, *, x, ~y]
-                ast[0].append(ast[1](*ast[2:], simplify=simplify))
-                ast = ast[0]
-
-    if isinstance(expr, basestring):
-        tokenized = tokenizer(expr, symbol_class=symbol_class)
-    else:
-        tokenized = iter(expr)
-
-    ast = [None, None]
-
-    for token, tokstr, position in tokenized:
-        if isinstance(token, Symbol) or token in (TRUE, FALSE,):
-            ast.append(token)
-        elif token == TOKEN_NOT:
-            ast = [ast, NOT]
-        elif token == TOKEN_AND:
-            ast = start_operation(ast, AND)
-        elif token == TOKEN_OR:
-            ast = start_operation(ast, OR)
-        elif token == TOKEN_LPAR:
-            ast = [ast, TOKEN_LPAR]
-        elif token == TOKEN_RPAR:
-            while True:
-                if ast[0] is None:
-                    raise TypeError('Bad closing parenthesis at position: %(position)r.' % locals())
-                if ast[1] is TOKEN_LPAR:
-                    ast[0].append(ast[2])
-                    ast = ast[0]
-                    break
-                ast[0].append(ast[1](*ast[2:], simplify=simplify))
-                ast = ast[0]
-        else:
-            raise TypeError('Unknown token: %(token)r: %(tokstr)r at position: %(position)r.' % locals())
-
-    while True:
-        if ast[0] is None:
-            if ast[1] is None:
-                assert len(ast) == 3, 'Invalid boolean expression'
-                parsed = ast[2]
-            else:
-                parsed = ast[1](*ast[2:], simplify=simplify)
-            break
-        else:
-            ast[0].append(ast[1](*ast[2:], simplify=simplify))
-            ast = ast[0]
-    return parsed
+        position += 1

--- a/boolean/boolean.py
+++ b/boolean/boolean.py
@@ -24,7 +24,6 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import itertools
-import sys
 
 try:
     basestring  # Python 2
@@ -799,26 +798,14 @@ class Function(Expression):
     elements TRUE or FALSE. Implemented functions are AND, OR and NOT.
     """
 
-    # Specifies how many arguments a function takes. the first number gives a
-    # lower limit/minimum, the second an upper limit/maximum number of args.
-    order = 2, sys.maxint
-
     def __init__(self, *args):
         super(Function, self).__init__()
-
-        minimum, maximum = self.order
-        args_length = len(args)
-
-        if minimum > args_length:
-            raise TypeError('Too few arguments. Got %(args_length)r, but need at least %(minimum)r.' % locals())
-        if maximum < args_length:
-            raise TypeError('Too many arguments. Got %(args_length)r, but need at most %(maximum)r.' % locals())
 
         # Specifies an infix notation of an operator for printing such as | or &.
         self.operator = None
 
-        # Make sure all arguments are boolean expressions.
-        assert all(isinstance(arg, Expression) for arg in args), 'Bad arguments: all arguments must be an Expression, TRUE or FALSE: %r' % (args,)
+        assert (all(isinstance(arg, Expression) for arg in args), 
+                'Bad arguments: all arguments must be an Expression: %r' % (args,))
         self.args = tuple(args)
 
     def __str__(self):
@@ -905,10 +892,9 @@ class NOT(Function):
             super(NOT2, self).__init__(*args)
             self.operator = '!'
     """
-    order = (1, 1)
 
-    def __init__(self, *args):
-        super(NOT, self).__init__(*args)
+    def __init__(self, arg1):
+        super(NOT, self).__init__(arg1)
         self.isliteral = self.args[0].isliteral
         self.operator = '~'
 
@@ -994,8 +980,8 @@ class DualBase(Function):
     "+" for OR and "*" for AND.
     """
 
-    def __init__(self, *args):
-        super(DualBase, self).__init__(*args)
+    def __init__(self, arg1, arg2, *args):
+        super(DualBase, self).__init__(arg1, arg2, *args)
 
         # identity element for the specific operation.
         # This will be TRUE for the AND operation and FALSE for the OR operation.
@@ -1315,8 +1301,8 @@ class AND(DualBase):
 
     sort_order = 10
 
-    def __init__(self, *args):
-        super(AND, self).__init__(*args)
+    def __init__(self, arg1, arg2, *args):
+        super(AND, self).__init__(arg1, arg2, *args)
         self.identity = self.TRUE
         self.annihilator = self.FALSE
         self.dual = self.OR
@@ -1339,8 +1325,8 @@ class OR(DualBase):
 
     sort_order = 25
 
-    def __init__(self, *args):
-        super(OR, self).__init__(*args)
+    def __init__(self, arg1, arg2, *args):
+        super(OR, self).__init__(arg1, arg2, *args)
         self.identity = self.FALSE
         self.annihilator = self.TRUE
         self.dual = self.AND

--- a/boolean/boolean.py
+++ b/boolean/boolean.py
@@ -470,21 +470,25 @@ class Expression(object):
         """
         return set(s.obj for s in self.symbols)
 
+    def get_literals(self):
+        """
+        Return a list of all the literals contained in this expression.
+        Include recursively subexpressions symbols.
+        This includes duplicates.
+        """
+        if self.isliteral:
+            return [self]
+        if not self.args:
+            return []
+        return list(itertools.chain.from_iterable(arg.literals for arg in self.args))
+
     @property
     def literals(self):
         """
         Return a set of all literals contained in this expression.
         Include recursively subexpressions literals.
         """
-        if self.isliteral:
-            return set((self,))
-        if not self.args:
-            return set()
-
-        s = set()
-        for arg in self.args:
-            s |= arg.literals
-        return s
+        return set(self.get_literals())
 
     def literalize(self):
         """
@@ -499,21 +503,22 @@ class Expression(object):
 
         return self.__class__(*args)
 
-    @property
-    def symbols(self):
+    def get_symbols(self):
         """
-        Return a set of all symbols contained in this expression.
+        Return a list of all the symbols contained in this expression.
         Include recursively subexpressions symbols.
+        This includes duplicates.
         """
-        if isinstance(self, Symbol):
-            return set([self])
-        if not self.args:
-            return set()
+        return [s for s in self.literals if isinstance(s, Symbol)]
 
-        s = set()
-        for arg in self.args:
-            s |= arg.symbols
-        return s
+    @property
+    def symbols(self, ):
+        """
+        Return a list of all the symbols contained in this expression.
+        Include recursively subexpressions symbols.
+        This includes duplicates.
+        """
+        return set(self.get_symbols())
 
     def subs(self, substitutions, simplify=True):
         """

--- a/boolean/boolean.py
+++ b/boolean/boolean.py
@@ -101,18 +101,18 @@ class ParseError(Exception):
 class BooleanAlgebra(object):
     """
     An algebra is defined by:
-    - the types of its operations and symbol.
+    - the types of its operations and Symbol.
     - the tokenizer used when parsing expressions from strings. 
     
     This class also serves as a base class for all boolean expressions,
     including base elements, functions and variable symbols.
     """
 
-    def __init__(self, TRUE_class=None, FALSE_class=None, symbol_class=None,
+    def __init__(self, TRUE_class=None, FALSE_class=None, Symbol_class=None,
                  NOT_class=None, AND_class=None, OR_class=None):
         """
-        The types for TRUE, FALSE, NOT, AND, OR and symbol define the boolean
-        algebra elements, operations and symbol variable. They default to the
+        The types for TRUE, FALSE, NOT, AND, OR and Symbol define the boolean
+        algebra elements, operations and Symbol variable. They default to the
         standard classes if not provided.
 
         You can customize an algebra by providing alternative subclasses of the
@@ -135,11 +135,11 @@ class BooleanAlgebra(object):
         self.OR = self._wrap_type(OR_class or OR)
 
         # class used for Symbols
-        self.symbol = self._wrap_type(symbol_class or Symbol)
+        self.Symbol = self._wrap_type(Symbol_class or Symbol)
 
         tf_nao = {'TRUE': self.TRUE, 'FALSE': self.FALSE,
                   'NOT': self.NOT, 'AND': self.AND, 'OR': self.OR,
-                  'symbol': self.symbol}
+                  'Symbol': self.Symbol}
 
         # setup cross references such that all algebra types and objects hold an
         # attribute for every other types and objects, including themselves.
@@ -165,15 +165,15 @@ class BooleanAlgebra(object):
     def definition(self):
         """
         Return a tuple of this algebra defined elements and types as:
-        (TRUE, FALSE, NOT, AND, OR, symbol)
+        (TRUE, FALSE, NOT, AND, OR, Symbol)
         """
-        return self.TRUE, self.FALSE, self.NOT, self.AND, self.OR, self.symbol
+        return self.TRUE, self.FALSE, self.NOT, self.AND, self.OR, self.Symbol
 
     def symbols(self, *args):
         """
-        Return a tuple of symbols building a new symbol from each argument.
+        Return a tuple of symbols building a new Symbol from each argument.
         """
-        return tuple(map(self.symbol, args))
+        return tuple(map(self.Symbol, args))
 
     def parse(self, expr, simplify=True):
         """
@@ -185,8 +185,8 @@ class BooleanAlgebra(object):
         Raise ParseError on errors.
         
         If `expr` is a string, the standard `tokenizer` is used for tokenization
-        and the algebra configured symbol type is used to create symbol
-        instances from symbol tokens.
+        and the algebra configured Symbol type is used to create Symbol
+        instances from Symbol tokens.
     
         If `expr` is an iterable, it should contain 3-tuples of: (token,
         token_string, position). In this case, the `token` can be a Symbol
@@ -205,7 +205,7 @@ class BooleanAlgebra(object):
 
         for token, tokstr, position in tokenized:
             if token == TOKEN_SYMBOL:
-                ast.append(self.symbol(tokstr))
+                ast.append(self.Symbol(tokstr))
             elif isinstance(token, Symbol):
                 ast.append(token)
 
@@ -460,7 +460,7 @@ class Expression(object):
     NOT = None
     AND = None
     OR = None
-    symbol = None
+    Symbol = None
 
     @property
     def objects(self):
@@ -512,7 +512,7 @@ class Expression(object):
         return [s for s in self.literals if isinstance(s, Symbol)]
 
     @property
-    def symbols(self, ):
+    def symbols(self,):
         """
         Return a list of all the symbols contained in this expression.
         Include recursively subexpressions symbols.
@@ -732,7 +732,7 @@ class Symbol(Expression):
     """
     Boolean variable.
     
-    A symbol can hold an object used to determine equality between symbols.
+    A Symbol can hold an object used to determine equality between symbols.
     """
 
     # FIXME: the statement below in the original docstring is weird: Symbols do
@@ -752,7 +752,7 @@ class Symbol(Expression):
         self.isliteral = True
 
     def __hash__(self):
-        if self.obj is None:  # Anonymous symbol.
+        if self.obj is None:  # Anonymous Symbol.
             return id(self)
         return hash(self.obj)
 

--- a/boolean/test_boolean.py
+++ b/boolean/test_boolean.py
@@ -54,8 +54,8 @@ class ExpressionTestCase(unittest.TestCase):
                         MySymbol('my'),
                         MySymbol('g'),
                     ),
-                    boolean.TRUE(),
-                    boolean.FALSE(),
+                    boolean.TRUE,
+                    boolean.FALSE,
                 ),
             ),
             MySymbol('that'),
@@ -68,14 +68,14 @@ class ExpressionTestCase(unittest.TestCase):
         E = boolean.Expression()
         expr = E.parse(expr_str, simplify=False)
         expected = boolean.OR(
-            boolean.TRUE(),
-            boolean.FALSE(),
-            boolean.FALSE(),
-            boolean.FALSE(),
-            boolean.TRUE(),
-            boolean.TRUE(),
-            boolean.FALSE(),
-            boolean.FALSE(),
+            boolean.TRUE,
+            boolean.FALSE,
+            boolean.FALSE,
+            boolean.FALSE,
+            boolean.TRUE,
+            boolean.TRUE,
+            boolean.FALSE,
+            boolean.FALSE,
         )
         self.assertEqual(expected, expr)
 
@@ -254,41 +254,48 @@ class BaseElementTestCase(unittest.TestCase):
 
     def test_creation(self):
         from boolean.boolean import BaseElement
-        self.assertEqual(boolean.TRUE(), boolean.TRUE())
+        self.assertEqual(boolean.TRUE, boolean.TRUE)
         BaseElement()
         self.assertRaises(TypeError, BaseElement, 2)
         self.assertRaises(TypeError, BaseElement, 'a')
+        self.assertTrue(boolean.TRUE is boolean.TRUE)
+        self.assertTrue(boolean.TRUE is not boolean.FALSE)
+        self.assertTrue(boolean.FALSE is boolean.FALSE)
+        self.assertTrue(bool(boolean.TRUE) is True)
+        self.assertTrue(bool(boolean.FALSE) is False)
+        self.assertEqual(boolean.TRUE, True)
+        self.assertEqual(boolean.FALSE, False)
 
     def test_literals(self):
-        self.assertEqual(boolean.TRUE().literals, set())
-        self.assertEqual(boolean.FALSE().literals, set())
+        self.assertEqual(boolean.TRUE.literals, set())
+        self.assertEqual(boolean.FALSE.literals, set())
 
     def test_literalize(self):
-        self.assertEqual(boolean.TRUE().literalize(), boolean.TRUE())
-        self.assertEqual(boolean.FALSE().literalize(), boolean.FALSE())
+        self.assertEqual(boolean.TRUE.literalize(), boolean.TRUE)
+        self.assertEqual(boolean.FALSE.literalize(), boolean.FALSE)
 
     def test_simplify(self):
-        self.assertEqual(boolean.TRUE().simplify(), boolean.TRUE())
-        self.assertEqual(boolean.FALSE().simplify(), boolean.FALSE())
+        self.assertEqual(boolean.TRUE.simplify(), boolean.TRUE)
+        self.assertEqual(boolean.FALSE.simplify(), boolean.FALSE)
 
     def test_dual(self):
-        self.assertEqual(boolean.TRUE().dual, boolean.FALSE())
-        self.assertEqual(boolean.FALSE().dual, boolean.TRUE())
+        self.assertEqual(boolean.TRUE.dual, boolean.FALSE)
+        self.assertEqual(boolean.FALSE.dual, boolean.TRUE)
 
     def test_equality(self):
-        self.assertEqual(boolean.TRUE(), boolean.TRUE())
-        self.assertEqual(boolean.FALSE(), boolean.FALSE())
-        self.assertNotEqual(boolean.TRUE(), boolean.FALSE())
+        self.assertEqual(boolean.TRUE, boolean.TRUE)
+        self.assertEqual(boolean.FALSE, boolean.FALSE)
+        self.assertNotEqual(boolean.TRUE, boolean.FALSE)
 
     def test_order(self):
-        self.assertTrue(boolean.FALSE() < boolean.TRUE())
-        self.assertTrue(boolean.TRUE() > boolean.FALSE())
+        self.assertTrue(boolean.FALSE < boolean.TRUE)
+        self.assertTrue(boolean.TRUE > boolean.FALSE)
 
     def test_printing(self):
-        self.assertEqual(str(boolean.TRUE()), '1')
-        self.assertEqual(str(boolean.FALSE()), '0')
-        self.assertEqual(repr(boolean.TRUE()), 'TRUE()')
-        self.assertEqual(repr(boolean.FALSE()), 'FALSE()')
+        self.assertEqual(str(boolean.TRUE), '1')
+        self.assertEqual(str(boolean.FALSE), '0')
+        self.assertEqual(repr(boolean.TRUE), 'TRUE')
+        self.assertEqual(repr(boolean.FALSE), 'FALSE')
 
 
 class SymbolTestCase(unittest.TestCase):
@@ -362,8 +369,8 @@ class NOTTestCase(unittest.TestCase):
         self.assertRaises(TypeError, NOT)
         self.assertRaises(TypeError, NOT, 'a', 'b')
         NOT(boolean.Symbol('a'))
-        self.assertEqual(boolean.FALSE(), (NOT(boolean.TRUE())).simplify())
-        self.assertEqual(boolean.TRUE(), (NOT(boolean.FALSE())).simplify())
+        self.assertEqual(boolean.FALSE, (NOT(boolean.TRUE)).simplify())
+        self.assertEqual(boolean.TRUE, (NOT(boolean.FALSE)).simplify())
 
     def test_isliteral(self):
         s = boolean.Symbol(1)
@@ -473,13 +480,13 @@ class DualBaseTestCase(unittest.TestCase):
 
     def test_annihilator(self):
         parse = boolean.Expression().parse
-        self.assertEqual(parse('a*a', simplify=False).annihilator, boolean.FALSE())
-        self.assertEqual(parse('a+a', simplify=False).annihilator, boolean.TRUE())
+        self.assertEqual(parse('a*a', simplify=False).annihilator, boolean.FALSE)
+        self.assertEqual(parse('a+a', simplify=False).annihilator, boolean.TRUE)
 
     def test_identity(self):
         parse = boolean.Expression().parse
-        self.assertEqual(parse('a+b').identity, boolean.FALSE())
-        self.assertEqual(parse('a*b').identity, boolean.TRUE())
+        self.assertEqual(parse('a+b').identity, boolean.FALSE)
+        self.assertEqual(parse('a*b').identity, boolean.TRUE)
 
     def test_dual(self):
         self.assertEqual(boolean.AND(boolean.Symbol('a'), boolean.Symbol('b')).dual, boolean.OR)
@@ -493,8 +500,8 @@ class DualBaseTestCase(unittest.TestCase):
         a = self.a
         b = self.b
         c = self.c
-        _0 = boolean.FALSE()
-        _1 = boolean.TRUE()
+        _0 = boolean.FALSE
+        _1 = boolean.TRUE
         # Idempotence
         self.assertEqual(a, (a * a).simplify())
         # Idempotence + Associativity
@@ -772,7 +779,7 @@ class OtherTestCase(unittest.TestCase):
         # FIXME: this test is cryptic: what does it do?
         parse = boolean.Expression().parse
         order = (
-            (boolean.TRUE(), boolean.FALSE()),
+            (boolean.TRUE, boolean.FALSE),
             (boolean.Symbol('y'), boolean.Symbol('x')),
             (parse('x*y'),),
             (parse('x+y'),),
@@ -788,10 +795,10 @@ class OtherTestCase(unittest.TestCase):
     def test_parse(self):
         a, b, c = boolean.Symbol('a'), boolean.Symbol('b'), boolean.Symbol('c')
         parse = boolean.Expression().parse
-        self.assertEqual(parse('0'), boolean.FALSE())
-        self.assertEqual(parse('(0)'), boolean.FALSE())
-        self.assertEqual(parse('1') , boolean.TRUE())
-        self.assertEqual(parse('(1)'), boolean.TRUE())
+        self.assertEqual(parse('0'), boolean.FALSE)
+        self.assertEqual(parse('(0)'), boolean.FALSE)
+        self.assertEqual(parse('1') , boolean.TRUE)
+        self.assertEqual(parse('(1)'), boolean.TRUE)
         self.assertEqual(parse('a'), a)
         self.assertEqual(parse('(a)'), a)
         self.assertEqual(parse('(a)'), a)
@@ -826,7 +833,7 @@ class OtherTestCase(unittest.TestCase):
         self.assertEqual(expr.subs({a: a}).simplify(), expr)
         self.assertEqual(expr.subs({a: b + c}).simplify(), boolean.Expression().parse('(b+c)*b+c').simplify())
         self.assertEqual(expr.subs({a * b: a}).simplify(), a + c)
-        self.assertEqual(expr.subs({c: boolean.TRUE()}).simplify(), boolean.TRUE())
+        self.assertEqual(expr.subs({c: boolean.TRUE}).simplify(), boolean.TRUE)
 
     def test_normalize(self):
         base = boolean.Expression()
@@ -841,15 +848,15 @@ class BooleanBoolTestCase(unittest.TestCase):
     def test_bool(self):
         a, b, c = boolean.Symbol('a'), boolean.Symbol('b'), boolean.Symbol('c')
         expr = a * b + c
-        self.assertRaises(TypeError, bool, expr.subs({a: boolean.TRUE()}, simplify=False))
-        self.assertRaises(TypeError, bool, expr.subs({b: boolean.TRUE()}, simplify=False))
-        self.assertRaises(TypeError, bool, expr.subs({c: boolean.TRUE()}, simplify=False))
-        self.assertRaises(TypeError, bool, expr.subs({a: boolean.TRUE(), b: boolean.TRUE()}, simplify=False))
-        result = expr.subs({c:boolean.TRUE()}, simplify=True)
+        self.assertRaises(TypeError, bool, expr.subs({a: boolean.TRUE}, simplify=False))
+        self.assertRaises(TypeError, bool, expr.subs({b: boolean.TRUE}, simplify=False))
+        self.assertRaises(TypeError, bool, expr.subs({c: boolean.TRUE}, simplify=False))
+        self.assertRaises(TypeError, bool, expr.subs({a: boolean.TRUE, b: boolean.TRUE}, simplify=False))
+        result = expr.subs({c:boolean.TRUE}, simplify=True)
         result = result.simplify()
         self.assertTrue(result)
 
-        result = expr.subs({a:boolean.TRUE(), b:boolean.TRUE()}, simplify=True)
+        result = expr.subs({a:boolean.TRUE, b:boolean.TRUE}, simplify=True)
         result = result.simplify()
         self.assertTrue(result)
 

--- a/boolean/test_boolean.py
+++ b/boolean/test_boolean.py
@@ -579,6 +579,24 @@ class DualBaseTestCase(unittest.TestCase):
         self.assertEqual(expected.pretty(), result.pretty())
 
     @expectedFailure
+    def test_parse_complex_expression_should_create_same_expression_as_python(self):
+        algebra = BooleanAlgebra()
+        a, b, c = algebra.symbols(*'abc')
+
+        test_expression_str = '''(~a | ~b | ~c)'''
+        parsed = algebra.parse(test_expression_str, simplify=False)
+        test_expression =  (~a | ~b | ~c )  #* ~d
+        # print()
+        # print('parsed')
+        # print(parsed.pretty())
+        # print('python')
+        # print(test_expression.pretty())
+        # we have a different behavior for expressions built from python expressions
+        # vs. expression built from an object tree vs. expression built from a parse
+        self.assertEqual(parsed.pretty(), test_expression.pretty())
+        self.assertEqual(parsed, test_expression)
+
+    @expectedFailure
     def test_simplify_complex_expression_parsed_with_simplify(self):
         # FIXME: THIS SHOULD NOT FAIL
         algebra = BooleanAlgebra()

--- a/boolean/test_boolean.py
+++ b/boolean/test_boolean.py
@@ -361,17 +361,17 @@ class SymbolTestCase(unittest.TestCase):
         d = algebra.symbol('d')
         e = algebra.symbol('e')
 
-#         # Test __eq__.
-#         self.assertTrue(a == a)
-#         self.assertTrue(a == a2)
-#         self.assertFalse(a == c)
-#         self.assertFalse(a2 == c)
-#         self.assertTrue(d == d)
-#         self.assertFalse(d == e)
-#         self.assertFalse(a == d)
-#         # Test __ne__.
-#         self.assertFalse(a != a)
-#         self.assertFalse(a != a2)
+        # Test __eq__.
+        self.assertTrue(a == a)
+        self.assertTrue(a == a2)
+        self.assertFalse(a == c)
+        self.assertFalse(a2 == c)
+        self.assertTrue(d == d)
+        self.assertFalse(d == e)
+        self.assertFalse(a == d)
+        # Test __ne__.
+        self.assertFalse(a != a)
+        self.assertFalse(a != a2)
         self.assertTrue(a != c)
         self.assertTrue(a2 != c)
 

--- a/boolean/test_boolean.py
+++ b/boolean/test_boolean.py
@@ -47,28 +47,28 @@ class BooleanAlgebraTestCase(unittest.TestCase):
                       d & ( ! e_
                       | (my * g OR 1 or 0) ) AND that '''
 
-        algebra = BooleanAlgebra(symbol_class=MySymbol)
+        algebra = BooleanAlgebra(Symbol_class=MySymbol)
         expr = algebra.parse(expr_str, simplify=False)
 
         expected = algebra.AND(
             algebra.OR(
-                algebra.symbol('a'),
-                algebra.NOT(algebra.symbol('b')),
-                algebra.symbol('_c'),
+                algebra.Symbol('a'),
+                algebra.NOT(algebra.Symbol('b')),
+                algebra.Symbol('_c'),
             ),
-            algebra.symbol('d'),
+            algebra.Symbol('d'),
             algebra.OR(
-                algebra.NOT(algebra.symbol('e_')),
+                algebra.NOT(algebra.Symbol('e_')),
                 algebra.OR(
                     algebra.AND(
-                        algebra.symbol('my'),
-                        algebra.symbol('g'),
+                        algebra.Symbol('my'),
+                        algebra.Symbol('g'),
                     ),
                     algebra.TRUE,
                     algebra.FALSE,
                 ),
             ),
-            algebra.symbol('that'),
+            algebra.Symbol('that'),
         )
 
         self.assertEqual(expected.pretty(), expr.pretty())
@@ -96,8 +96,8 @@ class BooleanAlgebraTestCase(unittest.TestCase):
             pass
 
         class CustomAlgebra(BooleanAlgebra):
-            def __init__(self, symbol_class=CustomSymbol):
-                super(CustomAlgebra, self).__init__(symbol_class=CustomSymbol)
+            def __init__(self, Symbol_class=CustomSymbol):
+                super(CustomAlgebra, self).__init__(Symbol_class=CustomSymbol)
 
             def tokenize(self, s):
                 "Sample tokenizer using custom operators and symbols"
@@ -114,7 +114,7 @@ class BooleanAlgebraTestCase(unittest.TestCase):
                         if tok in ops:
                             yield ops[tok], tok, (row, col)
                         elif tok == 'Custom':
-                            yield self.symbol(tok), tok, (row, col)
+                            yield self.Symbol(tok), tok, (row, col)
                         else:
                             yield TOKEN_SYMBOL, tok, (row, col)
 
@@ -126,13 +126,13 @@ class BooleanAlgebraTestCase(unittest.TestCase):
         expr = algebra.parse(expr_str, simplify=False)
         expected = algebra.AND(
             algebra.OR(
-                algebra.symbol('Custom'),
-                algebra.symbol('regular'),
+                algebra.Symbol('Custom'),
+                algebra.Symbol('regular'),
             ),
             algebra.NOT(
                 algebra.AND(
-                    algebra.symbol('not_custom'),
-                    algebra.symbol('standard'),
+                    algebra.Symbol('not_custom'),
+                    algebra.Symbol('standard'),
                 ),
             ),
         )
@@ -354,12 +354,12 @@ class SymbolTestCase(unittest.TestCase):
 
     def test_equal_symbols(self):
         algebra = BooleanAlgebra()
-        a = algebra.symbol('a')
-        a2 = algebra.symbol('a')
+        a = algebra.Symbol('a')
+        a2 = algebra.Symbol('a')
 
-        c = algebra.symbol('b')
-        d = algebra.symbol('d')
-        e = algebra.symbol('e')
+        c = algebra.Symbol('b')
+        d = algebra.Symbol('d')
+        e = algebra.Symbol('e')
 
         # Test __eq__.
         self.assertTrue(a == a)
@@ -395,19 +395,19 @@ class NOTTestCase(unittest.TestCase):
         algebra = BooleanAlgebra()
         self.assertRaises(TypeError, algebra.NOT)
         self.assertRaises(TypeError, algebra.NOT, 'a', 'b')
-        algebra.NOT(algebra.symbol('a'))
+        algebra.NOT(algebra.Symbol('a'))
         self.assertEqual(algebra.FALSE, (algebra.NOT(algebra.TRUE)).simplify())
         self.assertEqual(algebra.TRUE, (algebra.NOT(algebra.FALSE)).simplify())
 
     def test_isliteral(self):
         algebra = BooleanAlgebra()
-        s = algebra.symbol(1)
+        s = algebra.Symbol(1)
         self.assertTrue(algebra.NOT(s).isliteral)
         self.assertFalse(algebra.parse('~(a+b)').isliteral)
 
     def test_literals(self):
         algebra = BooleanAlgebra()
-        a = algebra.symbol('a')
+        a = algebra.Symbol('a')
         l = ~a
         self.assertTrue(l.isliteral)
         self.assertTrue(l in l.literals)
@@ -429,9 +429,9 @@ class NOTTestCase(unittest.TestCase):
 
     def test_simplify(self):
         algebra = BooleanAlgebra()
-        a = algebra.symbol('a')
+        a = algebra.Symbol('a')
         self.assertEqual(~a, ~a)
-        assert algebra.symbol('a') == algebra.symbol('a')
+        assert algebra.Symbol('a') == algebra.Symbol('a')
         self.assertNotEqual(a, algebra.parse('~~a', simplify=False))
         self.assertEqual(a, (~~a).simplify())
         self.assertEqual(~a, (~~ ~a).simplify())
@@ -441,7 +441,7 @@ class NOTTestCase(unittest.TestCase):
 
     def test_cancel(self):
         algebra = BooleanAlgebra()
-        a = algebra.symbol('a')
+        a = algebra.Symbol('a')
         self.assertEqual(~a, (~a).cancel())
         self.assertEqual(a, algebra.parse('~~a', simplify=False).cancel())
         self.assertEqual(~a, algebra.parse('~~~a', simplify=False).cancel())
@@ -449,16 +449,16 @@ class NOTTestCase(unittest.TestCase):
 
     def test_demorgan(self):
         algebra = BooleanAlgebra()
-        a = algebra.symbol('a')
-        b = algebra.symbol('b')
+        a = algebra.Symbol('a')
+        b = algebra.Symbol('b')
         self.assertEqual(algebra.parse('~(a*b)', simplify=False).demorgan(), ~a + ~b)
         self.assertEqual(algebra.parse('~(a+b+c)', simplify=False).demorgan(), algebra.parse('~a*~b*~c'))
         self.assertEqual(algebra.parse('~(~a*b)', simplify=False).demorgan(), a + ~b)
 
     def test_order(self):
         algebra = BooleanAlgebra()
-        x = algebra.symbol(1)
-        y = algebra.symbol(2)
+        x = algebra.Symbol(1)
+        y = algebra.Symbol(2)
         self.assertTrue(x < ~x)
         self.assertTrue(~x > x)
         self.assertTrue(~x < y)
@@ -466,7 +466,7 @@ class NOTTestCase(unittest.TestCase):
 
     def test_printing(self):
         algebra = BooleanAlgebra()
-        a = algebra.symbol('a')
+        a = algebra.Symbol('a')
         self.assertEqual(str(~a), '~a')
         self.assertEqual(repr(~a), "NOT(Symbol('a'))")
         expr = algebra.parse('~(a*a)', simplify=False)
@@ -530,17 +530,17 @@ class DualBaseTestCase(unittest.TestCase):
 
     def test_dual(self):
         algebra = BooleanAlgebra()
-        self.assertEqual(algebra.AND(algebra.symbol('a'), algebra.symbol('b')).dual, algebra.OR)
-        self.assertEqual(algebra.OR(algebra.symbol('a'), algebra.symbol('b')).dual, algebra.AND)
+        self.assertEqual(algebra.AND(algebra.Symbol('a'), algebra.Symbol('b')).dual, algebra.OR)
+        self.assertEqual(algebra.OR(algebra.Symbol('a'), algebra.Symbol('b')).dual, algebra.AND)
 
         self.assertEqual(algebra.parse('a+b').dual, algebra.AND)
         self.assertEqual(algebra.parse('a*b').dual, algebra.OR)
 
     def test_simplify(self):
         algebra = BooleanAlgebra()
-        a = algebra.symbol('a')
-        b = algebra.symbol('b')
-        c = algebra.symbol('c')
+        a = algebra.Symbol('a')
+        b = algebra.Symbol('b')
+        c = algebra.Symbol('c')
 
         _0 = algebra.FALSE
         _1 = algebra.TRUE
@@ -585,7 +585,7 @@ class DualBaseTestCase(unittest.TestCase):
 
         test_expression_str = '''(~a | ~b | ~c)'''
         parsed = algebra.parse(test_expression_str, simplify=False)
-        test_expression =  (~a | ~b | ~c )  #* ~d
+        test_expression = (~a | ~b | ~c)  # * ~d
         # print()
         # print('parsed')
         # print(parsed.pretty())
@@ -600,10 +600,10 @@ class DualBaseTestCase(unittest.TestCase):
     def test_simplify_complex_expression_parsed_with_simplify(self):
         # FIXME: THIS SHOULD NOT FAIL
         algebra = BooleanAlgebra()
-        a = algebra.symbol('a')
-        b = algebra.symbol('b')
-        c = algebra.symbol('c')
-        d = algebra.symbol('d')
+        a = algebra.Symbol('a')
+        b = algebra.Symbol('b')
+        c = algebra.Symbol('c')
+        d = algebra.Symbol('d')
 
         test_expression_str = '''
             (~a*~b*~c*~d) + (~a*~b*~c*d) + (~a*b*~c*~d) +
@@ -627,10 +627,10 @@ class DualBaseTestCase(unittest.TestCase):
     def test_complex_expression_without_parens_parsed_or_built_in_python_should_be_identical(self):
         # FIXME: THIS SHOULD NOT FAIL
         algebra = BooleanAlgebra()
-        a = algebra.symbol('a')
-        b = algebra.symbol('b')
-        c = algebra.symbol('c')
-        d = algebra.symbol('d')
+        a = algebra.Symbol('a')
+        b = algebra.Symbol('b')
+        c = algebra.Symbol('c')
+        d = algebra.Symbol('d')
 
         test_expression_str = '''
             ~a*~b*~c*~d + ~a*~b*~c*d + ~a*b*~c*~d +
@@ -653,10 +653,10 @@ class DualBaseTestCase(unittest.TestCase):
         # FIXME: THIS SHOULD NOT FAIL
 
         algebra = BooleanAlgebra()
-        a = algebra.symbol('a')
-        b = algebra.symbol('b')
-        c = algebra.symbol('c')
-        d = algebra.symbol('d')
+        a = algebra.Symbol('a')
+        b = algebra.Symbol('b')
+        c = algebra.Symbol('c')
+        d = algebra.Symbol('d')
         parse = algebra.parse
 
         test_expression_str = ''.join('''
@@ -694,63 +694,63 @@ class DualBaseTestCase(unittest.TestCase):
 
         expected = algebra.OR(
             algebra.AND(
-                algebra.NOT(algebra.symbol('a')),
-                algebra.NOT(algebra.symbol('b')),
-                algebra.NOT(algebra.symbol('c')),
-                algebra.NOT(algebra.symbol('d'))
+                algebra.NOT(algebra.Symbol('a')),
+                algebra.NOT(algebra.Symbol('b')),
+                algebra.NOT(algebra.Symbol('c')),
+                algebra.NOT(algebra.Symbol('d'))
             ),
             algebra.AND(
-                algebra.NOT(algebra.symbol('a')),
-                algebra.NOT(algebra.symbol('b')),
-                algebra.NOT(algebra.symbol('c')),
-                algebra.symbol('d')
+                algebra.NOT(algebra.Symbol('a')),
+                algebra.NOT(algebra.Symbol('b')),
+                algebra.NOT(algebra.Symbol('c')),
+                algebra.Symbol('d')
             ),
             algebra.AND(
-                algebra.NOT(algebra.symbol('a')),
-                algebra.symbol('b'),
-                algebra.NOT(algebra.symbol('c')),
-                algebra.NOT(algebra.symbol('d'))
+                algebra.NOT(algebra.Symbol('a')),
+                algebra.Symbol('b'),
+                algebra.NOT(algebra.Symbol('c')),
+                algebra.NOT(algebra.Symbol('d'))
             ),
             algebra.AND(
-                algebra.NOT(algebra.symbol('a')),
-                algebra.symbol('b'),
-                algebra.symbol('c'),
-                algebra.symbol('d')),
+                algebra.NOT(algebra.Symbol('a')),
+                algebra.Symbol('b'),
+                algebra.Symbol('c'),
+                algebra.Symbol('d')),
             algebra.AND(
-                algebra.NOT(algebra.symbol('a')),
-                algebra.symbol('b'),
-                algebra.NOT(algebra.symbol('c')),
-                algebra.symbol('d')
+                algebra.NOT(algebra.Symbol('a')),
+                algebra.Symbol('b'),
+                algebra.NOT(algebra.Symbol('c')),
+                algebra.Symbol('d')
             ),
             algebra.AND(
-                algebra.NOT(algebra.symbol('a')),
-                algebra.symbol('b'),
-                algebra.symbol('c'),
-                algebra.NOT(algebra.symbol('d'))
+                algebra.NOT(algebra.Symbol('a')),
+                algebra.Symbol('b'),
+                algebra.Symbol('c'),
+                algebra.NOT(algebra.Symbol('d'))
             ),
             algebra.AND(
-                algebra.symbol('a'),
-                algebra.NOT(algebra.symbol('b')),
-                algebra.NOT(algebra.symbol('c')),
-                algebra.symbol('d')
+                algebra.Symbol('a'),
+                algebra.NOT(algebra.Symbol('b')),
+                algebra.NOT(algebra.Symbol('c')),
+                algebra.Symbol('d')
             ),
             algebra.AND(
-                algebra.NOT(algebra.symbol('a')),
-                algebra.symbol('b'),
-                algebra.symbol('c'),
-                algebra.symbol('d')
+                algebra.NOT(algebra.Symbol('a')),
+                algebra.Symbol('b'),
+                algebra.Symbol('c'),
+                algebra.Symbol('d')
             ),
             algebra.AND(
-                algebra.symbol('a'),
-                algebra.NOT(algebra.symbol('b')),
-                algebra.symbol('c'),
-                algebra.symbol('d')
+                algebra.Symbol('a'),
+                algebra.NOT(algebra.Symbol('b')),
+                algebra.Symbol('c'),
+                algebra.Symbol('d')
             ),
             algebra.AND(
-                algebra.symbol('a'),
-                algebra.symbol('b'),
-                algebra.symbol('c'),
-                algebra.symbol('d')
+                algebra.Symbol('a'),
+                algebra.Symbol('b'),
+                algebra.Symbol('c'),
+                algebra.Symbol('d')
             )
         )
 
@@ -782,11 +782,11 @@ class DualBaseTestCase(unittest.TestCase):
 
     def test_distributive(self):
         algebra = BooleanAlgebra()
-        a = algebra.symbol('a')
-        b = algebra.symbol('b')
-        c = algebra.symbol('c')
-        d = algebra.symbol('d')
-        e = algebra.symbol('e')
+        a = algebra.Symbol('a')
+        b = algebra.Symbol('b')
+        c = algebra.Symbol('c')
+        d = algebra.Symbol('d')
+        e = algebra.Symbol('e')
         self.assertEqual((a * (b + c)).distributive(), (a * b) + (a * c))
         t1 = algebra.AND(a, (b + c), (d + e))
         t2 = algebra.OR(algebra.AND(a, b, d), algebra.AND(a, b, e), algebra.AND(a, c, d), algebra.AND(a, c, e))
@@ -821,7 +821,7 @@ class DualBaseTestCase(unittest.TestCase):
 
     def test_order(self):
         algebra = BooleanAlgebra()
-        x, y, z = algebra.symbol(1), algebra.symbol(2), algebra.symbol(3)
+        x, y, z = algebra.Symbol(1), algebra.Symbol(2), algebra.Symbol(3)
         self.assertTrue(algebra.AND(x, y) < algebra.AND(x, y, z))
         self.assertTrue(not algebra.AND(x, y) > algebra.AND(x, y, z))
         self.assertTrue(algebra.AND(x, y) < algebra.AND(x, z))
@@ -848,7 +848,7 @@ class OtherTestCase(unittest.TestCase):
         algebra = BooleanAlgebra()
         order = (
             (algebra.TRUE, algebra.FALSE),
-            (algebra.symbol('y'), algebra.symbol('x')),
+            (algebra.Symbol('y'), algebra.Symbol('x')),
             (algebra.parse('x*y'),),
             (algebra.parse('x+y'),),
         )
@@ -862,7 +862,7 @@ class OtherTestCase(unittest.TestCase):
 
     def test_parse(self):
         algebra = BooleanAlgebra()
-        a, b, c = algebra.symbol('a'), algebra.symbol('b'), algebra.symbol('c')
+        a, b, c = algebra.Symbol('a'), algebra.Symbol('b'), algebra.Symbol('c')
         self.assertEqual(algebra.parse('0'), algebra.FALSE)
         self.assertEqual(algebra.parse('(0)'), algebra.FALSE)
         self.assertEqual(algebra.parse('1') , algebra.TRUE)
@@ -896,7 +896,7 @@ class OtherTestCase(unittest.TestCase):
 
     def test_subs(self):
         algebra = BooleanAlgebra()
-        a, b, c = algebra.symbol('a'), algebra.symbol('b'), algebra.symbol('c')
+        a, b, c = algebra.Symbol('a'), algebra.Symbol('b'), algebra.Symbol('c')
         expr = a * b + c
         self.assertEqual(expr.subs({a: b}).simplify(), b + c)
         self.assertEqual(expr.subs({a: a}).simplify(), expr)
@@ -916,7 +916,7 @@ class BooleanBoolTestCase(unittest.TestCase):
 
     def test_bool(self):
         algebra = BooleanAlgebra()
-        a, b, c = algebra.symbol('a'), algebra.symbol('b'), algebra.symbol('c')
+        a, b, c = algebra.Symbol('a'), algebra.Symbol('b'), algebra.Symbol('c')
         expr = a * b + c
         self.assertRaises(TypeError, bool, expr.subs({a: algebra.TRUE}, simplify=False))
         self.assertRaises(TypeError, bool, expr.subs({b: algebra.TRUE}, simplify=False))

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -12,22 +12,28 @@ are stated.
 Basic Definitions
 -----------------
 
+Boolean Algebra
+^^^^^^^^^^^^^^^
+
+This is the main entry point. An algebra is define by the actual classes used
+for its domain, functions and variables.
+
 
 Boolean Domain
 ^^^^^^^^^^^^^^
 
 S := {1, 0}
 
-*These base elements are own classes with only one instance each,
+*These base elements are algebra-level singletons classes (only one instance of each per algebra instance),
 called* :class:`TRUE` *and* :class:`FALSE`.
 
 
 Boolean Variable
 ^^^^^^^^^^^^^^^^
 
-A variable that takes on only values in S.
+A variable holds an object and its implicit value is TRUE.
 
-*Implemented as class* :class:`Symbol`.
+*Implemented as class or subclasses of class* :class:`Symbol`.
 
 
 Boolean Function
@@ -83,9 +89,9 @@ elements
 +---+---+----------+
 
 and the property :math:`AND(x, y, z) = AND(x, AND(y, z))` where
-:math:`x, y, z` are boolean expressions.
+:math:`x, y, z` are boolean variables.
 
-Instead of :math:`AND(x, y, z)` one can write :math:`x*y*z`.
+Instead of :math:`AND(x, y, z)` one can write :math:`x & y & z`.
 
 *Implemented as class* :class:`AND`.
 
@@ -119,7 +125,7 @@ Instead of :math:`OR(x, y, z)` one can write :math:`x+y+z`.
 Literal
 ^^^^^^^
 
-A boolean variable or it's negation.
+A boolean variable, base element or its negation with NOT.
 
 *Implemented indirectly as* :attr:`Expression.isliteral`,
 :attr:`Expression.literals` *and* :meth:`Expression.literalize`.
@@ -130,6 +136,8 @@ Disjunctive normal form (DNF)
 A disjunction of conjunctions of literals where the conjunctions don't
 contain a boolean variable *and* it's negation. An example would be
 :math:`x*y + x*z`.
+
+*Implemented as* :attr:`BooleanAlgebra.dnf`.
 
 
 Full disjunctive normal form (FDNF)
@@ -146,6 +154,8 @@ Conjunctive normal form (CNF)
 A conjunction of disjunctions of literals where the disjunctions don't
 contain a boolean variable *and* it's negation. An example would be
 :math:`(x+y) * (x+z)`.
+
+*Implemented as* :attr:`BooleanAlgebra.cnf`.
 
 
 Full conjunctive normal form (FCNF)

--- a/docs/development_guide.rst
+++ b/docs/development_guide.rst
@@ -10,44 +10,52 @@ and laws are stated in :doc:`concepts`.
     :depth: 2
     :backlinks: top
 
-Layout
-------
+Classes Hierarchy
+-----------------
 ..
-    .. inheritance-diagram:: boolean.AND boolean.OR boolean.Symbol boolean.NOT
-                         boolean._TRUE boolean._FALSE boolean.DNF boolean.CNF
+    boolean.boolean.BooleanAlgebra
+    boolean.boolean.Expression
+        boolean.boolean.BaseElement
+            boolean.boolean._TRUE
+            boolean.boolean._FALSE
+        boolean.boolean.Symbol
+        boolean.boolean.Function
+            boolean.boolean.NOT
+            boolean.boolean.DualBase
+                boolean.boolean.AND
+                boolean.boolean.OR
 
-Classes
--------
+
 
 Expression
 ^^^^^^^^^^
 ..
-    .. autoclass:: boolean.Expression
+    .. autoclass:: boolean.boolean.Expression
 
 Symbol
 ^^^^^^
 ..
-    .. autoclass:: boolean.Symbol
+    .. autoclass:: boolean.boolean.Symbol
 
 Function
 ^^^^^^^^
 ..
-    .. autoclass:: boolean.Function
+    .. autoclass:: boolean.boolean.Function
 
 NOT
 ^^^
 ..
-    .. autoclass:: boolean.NOT
+    .. autoclass:: boolean.boolean.NOT
 
 AND
 ^^^
 ..
-    .. autoclass:: boolean.AND
+    .. autoclass:: boolean.boolean.AND
 
 OR
 ^^
 ..
-    .. autoclass:: boolean.OR
+    .. autoclass:: boolean.boolean.OR
 
 
 .. _class-creation:
@@ -55,32 +63,11 @@ OR
 Class creation
 --------------
 
-Not all calls to classes will result in instances of the corresponding class.
-In the following it is exactly listed which classes will return different
-instances for which types of arguments. So basically this section describes
-all implemented :meth:`__new__` methods.
+Except for BooleanAlgebra and Symbol, no other classes are is designed to be instantiated directly.
+Instead you should create a BooleanAlgebra instance, then use  BooleanAlgebra.symbol, 
+BooleanAlgebra.NOT, BooleanAlgebra.AND, BooleanAlgebra.OR BooleanAlgebra.TRUE and BooleanAlgebra.FALSE 
+to compose your expressions in the context of this algebra.
 
-Expression
-^^^^^^^^^^
-
-The :class:`expression` class can be used to transform any reasonable object
-into a boolean expression.
-
-* :obj:`Expression`
-* :obj:`str` --- :func:`parse` ---> :obj:`Expression`
-* :obj:`1` | :obj:`True` ---> :obj:`TRUE`
-* :obj:`0` | :obj:`False` ---> :obj:`FALSE`
-
-BaseElement
-^^^^^^^^^^^
-
-Probably this will not be used very often but for consistency the
-:class:`BaseElement` class will return the base elements of the boolean algebra
-if it is called with a meaningful argument.
-
-* :obj:`BaseElement`
-* :obj:`1` | :obj:`True` ---> :obj:`TRUE`
-* :obj:`0` | :obj:`False` ---> :obj:`FALSE`
 
 .. _class-initialization:
 
@@ -88,49 +75,38 @@ Class initialization
 --------------------
 
 In this section for all classes is stated which arguments they will accept
-(apart from the ones listed in :ref:`class-creation`) and how these arguments
-are processed before they are used.
+and how these arguments are processed before they are used.
 
 Symbol
 ^^^^^^
 
-* :obj:`None` (Anonymous Symbol)
 * :obj:`obj` (Named Symbol)
-
-Function
-^^^^^^^^
-
-A function can take an amount of arguments according to its order. These
-arguments may have the following types and are adequately processed:
-
-* :obj:`Expression`
-* :obj:`str` --- :func:`parse` ---> :obj:`Expression`
-* :obj:`1` | :obj:`True` ---> :obj:`TRUE`
-* :obj:`0` | :obj:`False` ---> :obj:`FALSE`
 
 
 Ordering
 --------
 
 As far as possible every expression should always be printed in exactly the
-same way. Therefor a strict ordering between different boolean classes and
-between instances of same classes is needed.
+same way. Therefore a strict ordering between different boolean classes and
+between instances of same classes is needed. This is defined primarily by the
+sort_order attribute.
+
 
 Class ordering
 ^^^^^^^^^^^^^^
 
-:class:`BaseElement` < :class:`Symbol` < :class:`AND` < :class:`CNF` <
-:class:`FCNF` < :class:`OR` < :class:`DNF` < :class:`FDNF`
+:class:`BaseElement` < :class:`Symbol` < :class:`AND` <  :class:`OR`
 
-:class:`NOT` is an exception in this scheme. It will be sorted by it's
+:class:`NOT` is an exception in this scheme. It will be sorted based on the sort order of its
 argument.
 
-Class ordering is implemented by an attribute :attr:`cls_order` in all
+Class ordering is implemented by an attribute :attr:`sort_order` in all
 relevant classes. It holds an integer that will be used for comparison
-if it is in both compared classes available.
-
+if it is available in both compared objects.
+For Symbols, the attached `obj` object is used instead.
+ 
 +----------------------+-----------+
-|    :class:`Class`    | cls_order |
+|    :class:`Class`    | sort_order|
 +======================+===========+
 | :class:`BaseElement` |    0      |
 +----------------------+-----------+
@@ -148,13 +124,8 @@ Instance ordering
     :obj:`FALSE` < :obj:`TRUE`
 
 :class:`Symbol`
-    :obj:`Named-Symbol` < :obj:`Anonymous-Symbol`
 
-    :obj:`Named-Symbol` o :obj:`Named-Symbol` --->
-    :obj:`Named-Symbol.arg[0]` o :obj:`Named-Symbol.arg[0]`
-
-    :obj:`Anonymous-Symbol` o :obj:`Anonymous-Symbol` --->
-    hash(:obj:`Anonymous-Symbol`) o hash(:obj:`Anonymous-Symbol`)
+    :obj:`Symbol.obj` o  :obj:`Symbol.obj`
 
 :class:`NOT`
     if :obj:`NOT.args[0]` == :obj:`other` ---> :obj:`other` < :obj:`NOT`
@@ -183,49 +154,8 @@ Instance ordering
 Parsing
 -------
 
-Parsing is done by iterating over all characters of a given string, creating
-adequate boolean objects as soon as possible and storing them in a list until
-they can be integrated into boolean objects by them selfs.
-
-Let's go through a simple example:
-
-    :obj:`x1+~x2`
-
-The first character is a "x". This indicates a symbol of yet unknown length.
-Therefore we search on until we find the end of the symbol and get the
-string "x1" which we use to create a new symbol. It's not determined what will
-happen with this symbol so we store it in a list of following structure:
-
-    :obj:`[None, None, Symbol("x1")]`
-
-Where the first position contains a pointer to the upper list (in this case
-None, since it isn't a subexpression) and the second determines which
-operation should be performed with the arguments in the following positions.
-Analysing the next character which is a "+" tells us that an OR operation is
-performed and we can update the current list to:
-
-    :obj:`[None, OR, Symbol("x1")]`
-
-The next character is a "~" (a NOT operation). Since we don't already know
-what will be inside this NOT operation we can't simply append a NOT(?) to
-the current list. Instead we will create a new list, storing the old one as
-first argument and NOT as second argument:
-
-    :obj:`[[None, OR, Symbol("x1")], NOT]`
-
-Proceeding the parsing we find the symbol "x2" which then is appended to the
-current list:
-
-    :obj:`[[None, OR, Symbol("x1")], NOT, Symbol("x2")]`
-
-Afterwards the end of the string is reached and everything can be finished.
-First, NOT(Symbol("x2")) is computed and appended to the parent list:
-
-    :obj:`[None, OR, Symbol("x1"), NOT(Symbol("x2"))]`
-
-Then the OR operation can be carried out:
-
-    :obj:`OR(Symbol("x1"), NOT(Symbol("x2")))`
-
-
+Parsing is done in two steps:
+A tokenizer iterates over string characters assigning a TOKEN_TYPE to each token.
+The parser receives this stream of token types and strings and creates
+adequate boolean objects from a parse tree.
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ Released under revised BSD license.
 
 setup(
     name='boolean.py',
-    version='2.0.dev1',
+    version='2.0.dev2',
     license='revised BSD license',
     description='Boolean Algreba',
     long_description=long_desc,

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     name='boolean.py',
     version='2.0.dev2',
     license='revised BSD license',
-    description='Boolean Algreba',
+    description='Define boolean algebras, create or parse boolean expressions and create custom boolean DSL.',
     long_description=long_desc,
     author='Sebastian Kraemer',
     author_email='basti.kr@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ Released under revised BSD license.
 
 setup(
     name='boolean.py',
-    version='2.0.dev2',
+    version='2.0.dev3',
     license='revised BSD license',
     description='Define boolean algebras, create or parse boolean expressions and create custom boolean DSL.',
     long_description=long_desc,

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,8 @@ This library helps you deal with boolean expressions and algebra with variables
 and the boolean functions AND, OR, NOT.
 
 You can parse expressions from strings and simplify and compare expressions.
-You can also easily create custom tokenizers to handle custom expressions.  
+You can also easily create your custom algreba and mini DSL and create custom
+tokenizers to handle custom expressions.  
 
 For extensive documentation look either into the docs directory or view it online, at
 https://booleanpy.readthedocs.org/en/latest/
@@ -26,9 +27,9 @@ Released under revised BSD license.
 
 setup(
     name='boolean.py',
-    version='2.0.dev3',
+    version='2.0.0',
     license='revised BSD license',
-    description='Define boolean algebras, create or parse boolean expressions and create custom boolean DSL.',
+    description='Define boolean algebras, create and parse boolean expressions and create custom boolean DSL.',
     long_description=long_desc,
     author='Sebastian Kraemer',
     author_email='basti.kr@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ Released under revised BSD license.
 
 setup(
     name='boolean.py',
-    version='1.2',
+    version='2.0.dev1',
     license='revised BSD license',
     description='Boolean Algreba',
     long_description=long_desc,


### PR DESCRIPTION
You cannot pass an expression or a string to the Expression constructor
anymore. Instead you build an Expression (which is really akin to an
algebra definition) and you can build expression with the configured
operations, symbol, base elements, etc. Or invoke `parse` on it to parse
from a string.

Creating an expression no longer invoke `simplify()` by default: it
needs to be called explicitly, though some method still retain a
simplify arg for convenience.

You can configure an Expression by providing alternative classes for
AND,OR,NOT,TRUE,FALSE,Symbol and the tokenizer function. In particular
you can subclass and customize the way expressions are printed or
represented.This supports #36

`parse`, `normalize`, `symbols` (now `build_symbols`) are methods of the
Expression object. `parse` now uses the symbol class of the configured
expression.

Several attributes shielded by a property are now just simple
attributes. TRUE and FALSE are no longer singletons: instead you can
instantiate them as needed.

A new `.pretty()` method is available and return a pretty formatted
representation of an Expression.


Some internal attributes or methods were renamed for clarity:
 -_cls_order is now `sort_order`.
 - References to cmp have been replaced by comparator.
 - `.remove` has been renamed to `.subtract` to avoid ambiguities with
the list.remove calls.