### PR TITLE
And parsing error

### DIFF
--- a/boolean/test_boolean.py
+++ b/boolean/test_boolean.py
@@ -781,6 +781,11 @@ class DualBaseTestCase(unittest.TestCase):
         result = result.simplify()
         self.assertEqual(expected, result)
 
+    def test_parse_invalid_nested_and_should_raise_a_proper_exception(self):
+        algebra = BooleanAlgebra()
+        test_expression_str = '''a (and b)'''
+        self.assertRaises(ParseError, algebra.parse, test_expression_str)
+
     def test_subtract(self):
         parse = BooleanAlgebra().parse
         expr = parse('a&b&c')

--- a/boolean/test_boolean.py
+++ b/boolean/test_boolean.py
@@ -3,7 +3,7 @@ Boolean Algebra.
 
 Tests
 
-Copyright (c) 2009-2010 Sebastian Kraemer, basti.kr@gmail.com
+Copyright (c) 2009-2016 Sebastian Kraemer, basti.kr@gmail.com and others
 Released under revised BSD license.
 """
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ Released under revised BSD license.
 
 setup(
     name='boolean.py',
-    version='3.0.dev4',
+    version='3.0.dev5',
     license='revised BSD license',
     description='Define boolean algebras, create and parse boolean expressions and create custom boolean DSL.',
     long_description=long_desc,


### PR DESCRIPTION
Incorrect expressions such as `xyz (and foo) raise a TypeError when parsed. While I am not sure this should be an error and would best best handled correctly, this PR now raises a proper ParseError instead 