### PR TITLE
Fix minor typos in docs and use self.assertRaises in a test

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2009-2010 Sebastian Kraemer, basti.kr@gmail.com
+Copyright (c) 2009-2017 Sebastian Kraemer, basti.kr@gmail.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/boolean/__init__.py
+++ b/boolean/__init__.py
@@ -6,7 +6,7 @@ variables and the boolean functions AND, OR, NOT. For extensive documentation
 look either into the docs directory or view it online, at
 https://booleanpy.readthedocs.org/en/latest/.
 
-Copyright (c) 2009-2010 Sebastian Kraemer, basti.kr@gmail.com
+Copyright (c) 2009-2017 Sebastian Kraemer, basti.kr@gmail.com
 Released under revised BSD license.
 """
 

--- a/boolean/boolean.py
+++ b/boolean/boolean.py
@@ -16,7 +16,7 @@ presented.
 For extensive documentation look either into the docs directory or view it
 online, at https://booleanpy.readthedocs.org/en/latest/.
 
-Copyright (c) 2009-2010 Sebastian Kraemer, basti.kr@gmail.com and others
+Copyright (c) 2009-2017 Sebastian Kraemer, basti.kr@gmail.com and others
 Released under revised BSD license.
 """
 

--- a/boolean/test_boolean.py
+++ b/boolean/test_boolean.py
@@ -3,7 +3,7 @@ Boolean Algebra.
 
 Tests
 
-Copyright (c) 2009-2016 Sebastian Kraemer, basti.kr@gmail.com and others
+Copyright (c) 2009-2017 Sebastian Kraemer, basti.kr@gmail.com and others
 Released under revised BSD license.
 """
 

--- a/boolean/test_boolean.py
+++ b/boolean/test_boolean.py
@@ -819,10 +819,13 @@ class DualBaseTestCase(unittest.TestCase):
     def test_parse_invalid_nested_and_should_raise_a_proper_exception(self):
         algebra = BooleanAlgebra()
         expr = '''a (and b)'''
-        try:
+
+        with self.assertRaises(ParseError) as context:
             algebra.parse(expr)
-        except ParseError as pe:
-            assert pe.error_code == PARSE_INVALID_NESTING
+
+            self.assertEqual(
+                context.exception.error_code, PARSE_INVALID_NESTING
+            )
 
     def test_subtract(self):
         parse = BooleanAlgebra().parse

--- a/docs/development_guide.rst
+++ b/docs/development_guide.rst
@@ -2,7 +2,7 @@
 Development Guide
 =================
 
-This document gives an overview of the code in &&boolean.py&&, explaining the
+This document gives an overview of the code in `boolean.py`, explaining the
 layout and design decisions and some difficult algorithms. All used definitions
 and laws are stated in :doc:`concepts`.
 

--- a/docs/users_guide.rst
+++ b/docs/users_guide.rst
@@ -78,8 +78,8 @@ You can build an expression by using the algebra functions::
 Evaluation of expressions
 -------------------------
 
-By default, an expression is not evaluated. You need to call the .simplify() 
-method explicitly an expression to perform some minimal 
+By default, an expression is not evaluated. You need to call the :meth:`simplify`
+method explicitly an expression to perform some minimal
 simplification to evaluate an expression:
 
 .. doctest:: boolean
@@ -114,7 +114,7 @@ When simplify() is called, the following boolean logic laws are used recursively
 
 Also double negations are canceled out (:ref:`double-negation`).
 
-A simplified expression is return and many not be fully evaluated nor minimal:
+A simplified expression is return and may not be fully evaluated nor minimal:
 
 .. doctest:: boolean
 
@@ -156,7 +156,7 @@ Symbols are equal if they are the same or their associated objects are equal.
 Equality of structure
 ^^^^^^^^^^^^^^^^^^^^^
 
-Here some examples of equal and unequal structures:
+Here are some examples of equal and unequal structures:
 
 .. doctest:: boolean
 
@@ -234,7 +234,7 @@ Or get a set() or list of all literals contained in an expression::
     >>> (~(x|~y)).get_literals()
     [Symbol('x'), NOT(Symbol('y'))]
 
-To remove negations except in literals use the :meth:`literalize`::
+To remove negations except in literals use :meth:`literalize`::
 
     >>> (~(x|~y)).literalize()
     ~x&y

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ https://booleanpy.readthedocs.org/en/latest/
 
 https://github.com/bastikr/boolean.py
 
-Copyright (c) 2009-2016 Sebastian Kraemer, basti.kr@gmail.com and others
+Copyright (c) 2009-2017 Sebastian Kraemer, basti.kr@gmail.com and others
 
 Released under revised BSD license.
 '''


### PR DESCRIPTION
Sorry for not making this PR atomic, it is just three small changes together:

1. Fixed all year ranges to end with 2017
2. Fixed a couple small typos in docs
3. Changed one test to use `self.assertRaises`

Now that test will fail if the exception is not raised. And it still checks the `error_code` of the exception (meaning, the test does not just end with a `self.assertRaises`). For details see:

http://stackoverflow.com/a/3166985/1269892

I am thinking about taking part in GSoC17 with AboutCode, possibly with the "porting the license expression library to JavaScript" because I have experience with both python and javascript. Please let me know if there are any other reasonable "steps forward" other than joining mail list/IRC (i.e. some projects rank applicants based on finished commts/PRs)

Update: nevermind, found https://gitter.im/aboutcode-org/discuss