### PR TITLE
Symbol / Literal fix suggestion (issue #59)

### DIFF
--- a/boolean/boolean.py
+++ b/boolean/boolean.py
@@ -580,7 +580,7 @@ class Expression(object):
         Include recursively subexpressions symbols.
         This includes duplicates.
         """
-        return [s for s in self.get_literals() if isinstance(s, Symbol)]
+        return [s if isinstance(s, Symbol) else s.args[0] for s in self.get_literals()]
 
     @property
     def symbols(self,):
@@ -971,7 +971,7 @@ class NOT(Function):
 
     def __init__(self, arg1):
         super(NOT, self).__init__(arg1)
-        self.isliteral = self.args[0].isliteral
+        self.isliteral = isinstance(self.args[0], Symbol)
         self.operator = '~'
 
     def literalize(self):

--- a/boolean/test_boolean.py
+++ b/boolean/test_boolean.py
@@ -1025,6 +1025,16 @@ class OtherTestCase(unittest.TestCase):
         exp = alg.parse('a and b or a and c')
         assert set([alg.Symbol('a'), alg.Symbol('b'), alg.Symbol('c')]) == exp.literals
 
+    def test_literals_and_negation(self):
+        alg = BooleanAlgebra()
+        exp = alg.parse('a and not b and not not c')
+        assert set([alg.Symbol('a'), alg.parse('not b'), alg.parse('not c')]) == exp.literals
+
+    def test_symbols_and_negation(self):
+        alg = BooleanAlgebra()
+        exp = alg.parse('a and not b and not not c')
+        assert set([alg.Symbol('a'), alg.Symbol('b'), alg.Symbol('c')]) == exp.symbols
+
     def test_objects_return_set_of_unique_Symbol_objs(self):
         alg = BooleanAlgebra()
         exp = alg.parse('a and b or a and c')


### PR DESCRIPTION
> A  literal is an a atomic formula or its negation.

`algebra.parse('Not(Not(X))').literals` will now produce `{NOT(Symbol('X'))}`
`algebra.parse('Not(Not(X))').symbols` will now produce `{Symbol('X')}`

Possible fix for issue #59

