### PR TITLE
Proper equivalence

### DIFF
--- a/boolean/boolean.py
+++ b/boolean/boolean.py
@@ -121,10 +121,10 @@ class BooleanAlgebra(object):
         standard types.
         """
         # TRUE and FALSE base elements are algebra-level "singleton" instances
-        self.TRUE = self._wrap_type(TRUE_class or _TRUE)
+        self.TRUE = TRUE_class or _TRUE
         self.TRUE = self.TRUE()
 
-        self.FALSE = self._wrap_type(TRUE_class or _FALSE)
+        self.FALSE = FALSE_class or _FALSE
         self.FALSE = self.FALSE()
 
         # they cross-reference each other
@@ -132,34 +132,27 @@ class BooleanAlgebra(object):
         self.FALSE.dual = self.TRUE
 
         # boolean operation types, defaulting to the standard types
-        self.NOT = self._wrap_type(NOT_class or NOT)
-        self.AND = self._wrap_type(AND_class or AND)
-        self.OR = self._wrap_type(OR_class or OR)
+        self.NOT = NOT_class or NOT
+        self.AND = AND_class or AND
+        self.OR = OR_class or OR
 
         # class used for Symbols
-        self.Symbol = self._wrap_type(Symbol_class or Symbol)
+        self.Symbol = Symbol_class or Symbol
 
-        tf_nao = {'TRUE': self.TRUE, 'FALSE': self.FALSE,
-                  'NOT': self.NOT, 'AND': self.AND, 'OR': self.OR,
-                  'Symbol': self.Symbol}
+        tf_nao = {
+            'TRUE': self.TRUE,
+            'FALSE': self.FALSE,
+            'NOT': self.NOT,
+            'AND': self.AND,
+            'OR': self.OR,
+            'Symbol': self.Symbol
+        }
 
-        # setup cross references such that all algebra types and objects hold an
-        # attribute for every other types and objects, including themselves.
-        self._cross_refs(tf_nao)
-
-    def _wrap_type(self, base_class):
-        """
-        Wrap the base class using its name as the name of the new type
-        """
-        return type(base_class.__name__, (base_class,), {})
-
-    def _cross_refs(self, objects):
-        """
-        Set every object as attributes of every object in an `objects` mapping
-        of (attribute name -> object)
-        """
-        for obj in objects.values():
-            for name, value in objects.items():
+        # setup cross references such that all algebra types and
+        # objects hold a named attribute for every other types and
+        # objects, including themselves.
+        for obj in tf_nao.values():
+            for name, value in tf_nao.items():
                 setattr(obj, name, value)
 
     def definition(self):
@@ -420,7 +413,8 @@ class BooleanAlgebra(object):
             'false': TOKEN_FALSE, '0': TOKEN_FALSE, 'none': TOKEN_FALSE
         }
 
-        position, length = 0, len(expr)
+        position = 0
+        length = len(expr)
 
         while position < length:
             tok = expr[position]

--- a/boolean/test_boolean.py
+++ b/boolean/test_boolean.py
@@ -356,6 +356,12 @@ class BaseElementTestCase(unittest.TestCase):
         self.assertEqual(algebra.TRUE.simplify(), algebra.TRUE)
         self.assertEqual(algebra.FALSE.simplify(), algebra.FALSE)
 
+    def test_simplify_two_algebra(self):
+        algebra1 = BooleanAlgebra()
+        algebra2 = BooleanAlgebra()
+        self.assertEqual(algebra1.TRUE.simplify(), algebra2.TRUE)
+        self.assertEqual(algebra1.FALSE.simplify(), algebra2.FALSE)
+
     def test_dual(self):
         algebra = BooleanAlgebra()
         self.assertEqual(algebra.TRUE.dual, algebra.FALSE)
@@ -409,6 +415,11 @@ class SymbolTestCase(unittest.TestCase):
     def test_simplify(self):
         s = Symbol(1)
         self.assertEqual(s.simplify(), s)
+
+    def test_simplify_different_instances(self):
+        s1 = Symbol(1)
+        s2 = Symbol(1)
+        self.assertEqual(s1.simplify(), s2.simplify())
 
     def test_equal_symbols(self):
         algebra = BooleanAlgebra()
@@ -496,6 +507,8 @@ class NOTTestCase(unittest.TestCase):
         self.assertEqual(a, (~~ ~~a).simplify())
         self.assertEqual((~(a & a & a)).simplify(), (~(a & a & a)).simplify())
         self.assertEqual(a, algebra.parse('~~a', simplify=True))
+        algebra2 = BooleanAlgebra()
+        self.assertEqual(a, algebra2.parse('~~a', simplify=True))
 
     def test_cancel(self):
         algebra = BooleanAlgebra()
@@ -595,13 +608,14 @@ class DualBaseTestCase(unittest.TestCase):
         self.assertEqual(algebra.parse('a&b').dual, algebra.OR)
 
     def test_simplify(self):
-        algebra = BooleanAlgebra()
-        a = algebra.Symbol('a')
-        b = algebra.Symbol('b')
-        c = algebra.Symbol('c')
+        algebra1 = BooleanAlgebra()
+        algebra2 = BooleanAlgebra()
+        a = algebra1.Symbol('a')
+        b = algebra1.Symbol('b')
+        c = algebra1.Symbol('c')
 
-        _0 = algebra.FALSE
-        _1 = algebra.TRUE
+        _0 = algebra1.FALSE
+        _1 = algebra1.TRUE
         # Idempotence
         self.assertEqual(a, (a & a).simplify())
         # Idempotence + Associativity
@@ -623,16 +637,29 @@ class DualBaseTestCase(unittest.TestCase):
         # Elimination
         self.assertEqual(a, ((a & ~b) | (a & b)).simplify())
 
-        expected = algebra.parse('(a&b)|(b&c)|(a&c)')
-        result = algebra.parse('(~a&b&c) | (a&~b&c) | (a&b&~c) | (a&b&c)', simplify=True)
+        expected = algebra1.parse('(a&b)|(b&c)|(a&c)')
+        result = algebra1.parse('(~a&b&c) | (a&~b&c) | (a&b&~c) | (a&b&c)', simplify=True)
         self.assertEqual(expected, result)
 
-        expected = algebra.parse('b&d')
-        result = algebra.parse('(a&b&c&d) | (b&d)', simplify=True)
+        expected = algebra1.parse('(a&b)|(b&c)|(a&c)')
+        result = algebra2.parse('(~a&b&c) | (a&~b&c) | (a&b&~c) | (a&b&c)', simplify=True)
         self.assertEqual(expected, result)
 
-        expected = algebra.parse('(~b&~d&a) | (~c&~d&b) | (a&c&d)', simplify=True)
-        result = algebra.parse('''(~a&b&~c&~d) | (a&~b&~c&~d) | (a&~b&c&~d) |
+        expected = algebra1.parse('b&d')
+        result = algebra1.parse('(a&b&c&d) | (b&d)', simplify=True)
+        self.assertEqual(expected, result)
+
+        expected = algebra1.parse('b&d')
+        result = algebra2.parse('(a&b&c&d) | (b&d)', simplify=True)
+        self.assertEqual(expected, result)
+
+        expected = algebra1.parse('(~b&~d&a) | (~c&~d&b) | (a&c&d)', simplify=True)
+        result = algebra1.parse('''(~a&b&~c&~d) | (a&~b&~c&~d) | (a&~b&c&~d) |
+                          (a&~b&c&d) | (a&b&~c&~d) | (a&b&c&d)''', simplify=True)
+        self.assertEqual(expected.pretty(), result.pretty())
+
+        expected = algebra1.parse('(~b&~d&a) | (~c&~d&b) | (a&c&d)', simplify=True)
+        result = algebra2.parse('''(~a&b&~c&~d) | (a&~b&~c&~d) | (a&~b&c&~d) |
                           (a&~b&c&d) | (a&b&~c&~d) | (a&b&c&d)''', simplify=True)
         self.assertEqual(expected.pretty(), result.pretty())
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ Released under revised BSD license.
 
 setup(
     name='boolean.py',
-    version='3.4',
+    version='3.5',
     license='revised BSD license',
     description='Define boolean algebras, create and parse boolean expressions and create custom boolean DSL.',
     long_description=long_desc,


### PR DESCRIPTION
This is a fix for the cases where two expression where built from two different algebras and need to be compared (such as a comparing two simplified versions).
I had add some weird type wrapping in the past for reasons I cannot fathom. These precluded any `isinstance` checks to work as new types were created each time. Removing this wart creates no issue and solves the problem, originally reported as part of https://github.com/nexB/license-expression/issues/21 