### PR TITLE
Fixing De Morgan's laws effect on double negation propositions

### DIFF
--- a/boolean/boolean.py
+++ b/boolean/boolean.py
@@ -1041,7 +1041,7 @@ class NOT(Function):
         This is achieved by canceling double NOTs and using De Morgan laws.
         """
         expr = self.cancel()
-        if expr.isliteral or not isinstance(expr.args[0], (self.NOT, self.AND, self.OR)):
+        if expr.isliteral or not isinstance(expr, self.NOT):
             return expr
         op = expr.args[0]
         return op.dual(*(self.__class__(arg).cancel() for arg in op.args))

--- a/boolean/test_boolean.py
+++ b/boolean/test_boolean.py
@@ -522,10 +522,14 @@ class NOTTestCase(unittest.TestCase):
         algebra = BooleanAlgebra()
         a = algebra.Symbol('a')
         b = algebra.Symbol('b')
+        c = algebra.Symbol('c')
         self.assertEqual(algebra.parse('~(a&b)').demorgan(), ~a | ~b)
         self.assertEqual(algebra.parse('~(a|b|c)').demorgan(), algebra.parse('~a&~b&~c'))
         self.assertEqual(algebra.parse('~(~a&b)').demorgan(), a | ~b)
-        self.assertEqual(algebra.parse('~~(a&b|c)').demorgan(), algebra.parse('a&b|c'))
+        self.assertEqual((~~(a&b|c)).demorgan(), a&b|c)
+        self.assertEqual((~~~(a&b|c)).demorgan(), ~(a&b)&~c)
+        self.assertEqual(algebra.parse('~'*10 + '(a&b|c)').demorgan(), a&b|c)
+        self.assertEqual(algebra.parse('~'*11 + '(a&b|c)').demorgan(), (~(a&b|c)).demorgan())
 
     def test_order(self):
         algebra = BooleanAlgebra()

--- a/boolean/test_boolean.py
+++ b/boolean/test_boolean.py
@@ -525,6 +525,7 @@ class NOTTestCase(unittest.TestCase):
         self.assertEqual(algebra.parse('~(a&b)').demorgan(), ~a | ~b)
         self.assertEqual(algebra.parse('~(a|b|c)').demorgan(), algebra.parse('~a&~b&~c'))
         self.assertEqual(algebra.parse('~(~a&b)').demorgan(), a | ~b)
+        self.assertEqual(algebra.parse('~~(a&b|c)').demorgan(), algebra.parse('a&b|c'))
 
     def test_order(self):
         algebra = BooleanAlgebra()


### PR DESCRIPTION
The result of the application of De Morgan's laws on an expression should remain unaltered when the same expression is negated an even number of times. However, this does not hold. This is a (simplistic, tentative) fix for such issue.