### PR TITLE
Add sort keyword argument to DualBase simplify()

### DIFF
--- a/boolean/boolean.py
+++ b/boolean/boolean.py
@@ -1135,7 +1135,7 @@ class DualBase(Function):
         if isinstance(expr, self.__class__):
             return all(arg in self.args for arg in expr.args)
 
-    def simplify(self):
+    def simplify(self, sort=True):
         """
         Return a new simplified expression in canonical form from this
         expression.
@@ -1254,7 +1254,8 @@ class DualBase(Function):
             return args[0]
 
         # Commutativity: A & B = B & A, A | B = B | A
-        args.sort()
+        if sort:
+            args.sort()
 
         # Create new (now canonical) expression.
         expr = self.__class__(*args)

--- a/boolean/test_boolean.py
+++ b/boolean/test_boolean.py
@@ -705,6 +705,17 @@ class DualBaseTestCase(unittest.TestCase):
         # Elimination
         self.assertEqual(a, ((a & ~b) | (a & b)).simplify())
 
+        # Commutativity + Non-Commutativity 
+        sorted_expression = (b & b & a).simplify()
+        unsorted_expression = (b & b & a).simplify(sort=False)
+        self.assertEqual(sorted_expression, unsorted_expression)
+        self.assertNotEqual(sorted_expression.pretty(), unsorted_expression.pretty())
+
+        sorted_expression = (b | b | a).simplify()
+        unsorted_expression = (b | b | a).simplify(sort=False)
+        self.assertEqual(sorted_expression, unsorted_expression)
+        self.assertNotEqual(sorted_expression.pretty(), unsorted_expression.pretty())
+
         expected = algebra1.parse('(a&b)|(b&c)|(a&c)')
         result = algebra1.parse('(~a&b&c) | (a&~b&c) | (a&b&~c) | (a&b&c)', simplify=True)
         self.assertEqual(expected, result)


### PR DESCRIPTION
This commit adds a "sort" keyword argument to the simplify() function of
the DualBase class. This allows simplification of boolean algebra
expressions to be completed correctly, but does not sort the final
expression. This is needed for various applications where maintaining order matters.

Signed-off-by: Steven Esser <sesser@nexb.com>