### PR TITLE
Remove py2-incompatible use of print statement.

### DIFF
--- a/boolean/boolean.py
+++ b/boolean/boolean.py
@@ -204,7 +204,8 @@ class BooleanAlgebra(object):
         if TRACE_PARSE:
             tokenized = list(tokenized)
             print('tokens:')
-            map(print, tokenized)
+            for t in tokenized:
+                print(t)
             tokenized = iter(tokenized)
 
         # the abstract syntax tree for this expression that will be build as we


### PR DESCRIPTION
In python 2 print is a statement, not a function, so it cannot
be used as the first argument to map().