### PR TITLE
Fix dual for _TRUE and _FALSE

### DIFF
--- a/boolean/boolean.py
+++ b/boolean/boolean.py
@@ -838,6 +838,9 @@ class _TRUE(BaseElement):
     def __repr__(self):
         return 'TRUE'
 
+    def __call__(self):
+        return self
+
     __nonzero__ = __bool__ = lambda s: True
 
 
@@ -862,6 +865,9 @@ class _FALSE(BaseElement):
 
     def __repr__(self):
         return 'FALSE'
+
+    def __call__(self):
+        return self
 
     __nonzero__ = __bool__ = lambda s: False
 

--- a/boolean/test_boolean.py
+++ b/boolean/test_boolean.py
@@ -606,6 +606,10 @@ class NOTTestCase(unittest.TestCase):
         self.assertEqual((~ ~ ~(a & b | c)).demorgan(), ~(a & b) & ~c)
         self.assertEqual(algebra.parse('~' * 10 + '(a&b|c)').demorgan(), a & b | c)
         self.assertEqual(algebra.parse('~' * 11 + '(a&b|c)').demorgan(), (~(a & b | c)).demorgan())
+        _0 = algebra.FALSE
+        _1 = algebra.TRUE
+        self.assertEqual((~(_0)).demorgan(), _1)
+        self.assertEqual((~(_1)).demorgan(), _0)
 
     def test_order(self):
         algebra = BooleanAlgebra()


### PR DESCRIPTION
The `dual` member of operators is assumed to be a class. However, for `TRUE` and `FALSE`, it is an object.

This leads to errors with `simplify()` or `literalize()` within the `demorgan()` method when applied on `TRUE` or `FALSE` objects (e.g., #85)

There are two ways of fixing this: either assign the dual member of `TRUE` and `FALSE` to the corresponding class, or add a `__call__` method to these objects returning themselves.

This PR adopts the latter approach to respect as much as possible the singleton design pattern.