### PR TITLE
Performance: prevent blowup in normalization

### DIFF
--- a/boolean/test_boolean.py
+++ b/boolean/test_boolean.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 
+import time
 import unittest
 from unittest.case import expectedFailure
 
@@ -1164,6 +1165,32 @@ class OtherTestCase(unittest.TestCase):
         alg = BooleanAlgebra()
         exp = alg.parse('a and b or a and c')
         assert set(['a', 'b', 'c']) == exp.objects
+
+    def test_normalize_blowup(self):
+        # Real-world example of a complex expression with simple CNF/DNF form.
+        # Note this is a more reduced, milder version of the problem, for rapid
+        # testing.
+        formula = """
+        a & (
+            (b & c & d & e & f & g)
+            | (c & f & g & h & i & j)
+            | (c & d & f & g & i & l & o & u)
+            | (c & e & f & g & i & p & y & ~v)
+            | (c & f & g & i & j & z & ~(c & f & g & i & j & k))
+            | (c & f & g & t & ~(b & c & d & e & f & g))
+            | (c & f & g & ~t & ~(b & c & d & e & f & g))
+        )
+        """
+        algebra = BooleanAlgebra()
+        expr = algebra.parse(formula)
+        t0 = time.time()
+        cnf = algebra.cnf(expr)
+        t1 = time.time()
+
+        assert str(cnf) == "a&c&f&g"
+        # Locally, this test takes 0.4s, previously it was 500s.
+        # We allow 30s because of the wide range of possible CPUs.
+        assert t1 - t0 < 30, "Normalizing took too long"
 
 
 class BooleanBoolTestCase(unittest.TestCase):


### PR DESCRIPTION
This addresses the case where we have an expression which is small when normalized, but in its current form contains large dual expressions. The blowup happens at the `_rdistributive` step, so the idea is to normalize subexpressions as much as possible before that. Closes https://github.com/bastikr/boolean.py/issues/106

The current test case takes 0.4s with the new code, but took 500s with the old code. We have many of these cases in our codebase and the blow-up is exponential in the size of the original expression. We have tested and this now has reasonable performance with all formulas from our codebase.

The original expression which drew our attention to this issue (below) now takes 30s (~3s under pypy) with the new code and never returns (in fact I run out of memory) with the old code:

```
        a & (
            (b & c & d & e & f & g)
            | (c & d & f & g & i & j)
            | (c & f & g & h & i & j)
            | (c & f & g & i & j & k)
            | (c & d & f & g & i & n & p)
            | (c & e & f & g & i & m & x)
            | (c & e & f & g & l & o & w)
            | (c & e & f & g & q & s & t)
            | (c & f & g & i & m & n & r)
            | (c & f & g & l & n & o & r)
            | (c & d & f & g & i & l & o & u)
            | (c & e & f & g & i & p & y & ~v)
            | (c & f & g & i & j & z & ~(c & f & g & i & j & k))
            | (
                c & f & g & t
                & ~(b & c & d & e & f & g)
                & ~(c & d & f & g & i & j)
                & ~(c & f & g & h & i & j)
                & ~(c & f & g & i & j & k)
                & ~(c & d & f & g & i & n & p)
                & ~(c & e & f & g & i & m & x)
                & ~(c & e & f & g & l & o & w)
                & ~(c & e & f & g & q & s & t)
                & ~(c & f & g & i & m & n & r)
                & ~(c & f & g & l & n & o & r)
                & ~(c & d & f & g & i & l & o & u)
                & ~(c & e & f & g & i & p & y & ~v)
                & ~(c & f & g & i & j & z & ~(c & f & g & i & j & k))
            )
            | (
                c & f & g & ~t
                & ~(b & c & d & e & f & g)
                & ~(c & d & f & g & i & j)
                & ~(c & f & g & h & i & j)
                & ~(c & f & g & i & j & k)
                & ~(c & d & f & g & i & n & p)
                & ~(c & e & f & g & i & m & x)
                & ~(c & e & f & g & l & o & w)
                & ~(c & e & f & g & q & s & t)
                & ~(c & f & g & i & m & n & r)
                & ~(c & f & g & l & n & o & r)
                & ~(c & d & f & g & i & l & o & u)
                & ~(c & e & f & g & i & p & y & ~v)
                & ~(c & f & g & i & j & z & ~(c & f & g & i & j & k))
            )
        )
```