### PR TITLE
doc: add API reference

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -74,3 +74,23 @@ jobs:
 
             - name: Run tests
               run: pytest -vvs boolean
+
+    docs:
+      name: Generate docs
+      runs-on: ubuntu-20.04
+
+      steps:
+          - uses: actions/checkout@v2
+
+          - name: Checkout and install reqs
+            run: |
+                pip install --upgrade --user -e .[docs]
+
+          - name: Gen docs
+            run: |
+                make -C docs html
+
+          - name: Collect docs
+            uses: actions/upload-artifact@v2
+            with:
+                path: docs/build/

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /.idea/
 .python-version
 /venv/
+/docs/

--- a/boolean/__init__.py
+++ b/boolean/__init__.py
@@ -7,6 +7,7 @@ look either into the docs directory or view it online, at
 https://booleanpy.readthedocs.org/en/latest/.
 
 Copyright (c) Sebastian Kraemer, basti.kr@gmail.com and others
+
 SPDX-License-Identifier: BSD-2-Clause
 """
 

--- a/boolean/boolean.py
+++ b/boolean/boolean.py
@@ -447,6 +447,7 @@ class BooleanAlgebra(object):
         unicode string.
 
         This 3-tuple contains (token, token string, position):
+
         - token: either a Symbol instance or one of TOKEN_* token types.
         - token string: the original token unicode string.
         - position: some simple object describing the starting position of the
@@ -464,27 +465,32 @@ class BooleanAlgebra(object):
         tests for other examples of alternative tokenizers.
 
         This tokenizer has these characteristics:
+
         - The `expr` string can span multiple lines,
         - Whitespace is not significant.
         - The returned position is the starting character offset of a token.
-
         - A TOKEN_SYMBOL is returned for valid identifiers which is a string
-        without spaces. These are valid identifiers:
-            - Python identifiers.
-            - a string even if starting with digits
-            - digits (except for 0 and 1).
-            - dotted names : foo.bar consist of one token.
-            - names with colons: foo:bar consist of one token.
-            These are not identifiers:
-            - quoted strings.
-            - any punctuation which is not an operation
+          without spaces.
+
+            - These are valid identifiers:
+                - Python identifiers.
+                - a string even if starting with digits
+                - digits (except for 0 and 1).
+                - dotted names : foo.bar consist of one token.
+                - names with colons: foo:bar consist of one token.
+            
+            - These are not identifiers:
+                - quoted strings.
+                - any punctuation which is not an operation
 
         - Recognized operators are (in any upper/lower case combinations):
+
             - for and:  '*', '&', 'and'
             - for or: '+', '|', 'or'
             - for not: '~', '!', 'not'
 
         - Recognized special symbols are (in any upper/lower case combinations):
+
             - True symbols: 1 and True
             - False symbols: 0, False and None
         """
@@ -572,7 +578,8 @@ class BooleanAlgebra(object):
         given AND or OR operation.
 
         The new expression arguments will satisfy these conditions:
-        - operation(*args) == expr (here mathematical equality is meant)
+    
+        - ``operation(*args) == expr`` (here mathematical equality is meant)
         - the operation does not occur in any of its arg.
         - NOT is only appearing in literals (aka. Negation normal form).
 
@@ -1073,7 +1080,7 @@ class Function(Expression):
         For example::
 
             >>> print(BooleanAlgebra().parse(
-            ...    u'not a and not b and not (a and ba and c) and c or c').pretty())
+            >>>    u'not a and not b and not (a and ba and c) and c or c').pretty())
             OR(
               AND(
                 NOT(Symbol('a')),
@@ -1129,9 +1136,9 @@ class NOT(Function):
     For example::
 
     >>> class NOT2(NOT):
-    ...     def __init__(self, *args):
-    ...         super(NOT2, self).__init__(*args)
-    ...         self.operator = '!'
+    >>>     def __init__(self, *args):
+    >>>         super(NOT2, self).__init__(*args)
+    >>>         self.operator = '!'
     """
 
     def __init__(self, arg1):
@@ -1264,6 +1271,7 @@ class DualBase(Function):
 
         For simplification of AND and OR fthe ollowing rules are used
         recursively bottom up:
+
          - Associativity (output does not contain same operations nested)
          - Annihilation
          - Idempotence
@@ -1557,10 +1565,11 @@ class AND(DualBase):
 
     You can subclass to define alternative string representation.
     For example::
+
     >>> class AND2(AND):
-    ...     def __init__(self, *args):
-    ...         super(AND2, self).__init__(*args)
-    ...         self.operator = 'AND'
+    >>>     def __init__(self, *args):
+    >>>         super(AND2, self).__init__(*args)
+    >>>         self.operator = 'AND'
     """
 
     _pyoperator = and_operator
@@ -1584,9 +1593,9 @@ class OR(DualBase):
     For example::
 
     >>> class OR2(OR):
-    ...     def __init__(self, *args):
-    ...         super(OR2, self).__init__(*args)
-    ...         self.operator = 'OR'
+    >>>     def __init__(self, *args):
+    >>>         super(OR2, self).__init__(*args)
+    >>>         self.operator = 'OR'
     """
 
     _pyoperator = or_operator

--- a/boolean/boolean.py
+++ b/boolean/boolean.py
@@ -17,6 +17,7 @@ For extensive documentation look either into the docs directory or view it
 online, at https://booleanpy.readthedocs.org/en/latest/.
 
 Copyright (c) Sebastian Kraemer, basti.kr@gmail.com and others
+
 SPDX-License-Identifier: BSD-2-Clause
 """
 
@@ -99,6 +100,7 @@ class ParseError(Exception):
 class BooleanAlgebra(object):
     """
     An algebra is defined by:
+
     - the types of its operations and Symbol.
     - the tokenizer used when parsing expressions from strings.
 
@@ -1077,25 +1079,25 @@ class Function(Expression):
 
         If debug is True, also prints debug information for each expression arg.
 
-        For example::
+        For example:
 
-            >>> print(BooleanAlgebra().parse(
-            >>>    u'not a and not b and not (a and ba and c) and c or c').pretty())
-            OR(
+        >>> print(BooleanAlgebra().parse(
+        ...    u'not a and not b and not (a and ba and c) and c or c').pretty())
+        OR(
+          AND(
+            NOT(Symbol('a')),
+            NOT(Symbol('b')),
+            NOT(
               AND(
-                NOT(Symbol('a')),
-                NOT(Symbol('b')),
-                NOT(
-                  AND(
-                    Symbol('a'),
-                    Symbol('ba'),
-                    Symbol('c')
-                  )
-                ),
+                Symbol('a'),
+                Symbol('ba'),
                 Symbol('c')
-              ),
-              Symbol('c')
-            )
+              )
+            ),
+            Symbol('c')
+          ),
+          Symbol('c')
+        )
         """
         debug_details = ""
         if debug:
@@ -1133,12 +1135,12 @@ class NOT(Function):
 
     You can subclass to define alternative string representation.
 
-    For example::
+    For example:
 
     >>> class NOT2(NOT):
-    >>>     def __init__(self, *args):
-    >>>         super(NOT2, self).__init__(*args)
-    >>>         self.operator = '!'
+    ...     def __init__(self, *args):
+    ...         super(NOT2, self).__init__(*args)
+    ...         self.operator = '!'
     """
 
     def __init__(self, arg1):
@@ -1233,7 +1235,7 @@ class DualBase(Function):
     Base class for AND and OR function.
 
     This class uses the duality principle to combine similar methods of AND
-    and OR. Both operations take 2 or more arguments and can be created using
+    and OR. Both operations take two or more arguments and can be created using
     "|" for OR and "&" for AND.
     """
 
@@ -1272,14 +1274,43 @@ class DualBase(Function):
         For simplification of AND and OR fthe ollowing rules are used
         recursively bottom up:
 
-         - Associativity (output does not contain same operations nested)
-         - Annihilation
-         - Idempotence
-         - Identity
-         - Complementation
-         - Elimination
-         - Absorption
-         - Commutativity (output is always sorted)
+        - Associativity (output does not contain same operations nested)::
+
+            (A & B) & C = A & (B & C) = A & B & C
+            (A | B) | C = A | (B | C) = A | B | C
+         
+         
+        - Annihilation::
+
+            A & 0 = 0, A | 1 = 1
+
+        - Idempotence (e.g. removing duplicates)::
+
+            A & A = A, A | A = A
+
+        - Identity::
+
+            A & 1 = A, A | 0 = A
+
+        - Complementation::
+
+            A & ~A = 0, A | ~A = 1
+
+        - Elimination::
+
+            (A & B) | (A & ~B) = A, (A | B) & (A | ~B) = A
+
+        - Absorption::
+
+            A & (A | B) = A, A | (A & B) = A
+
+        - Negative absorption::
+
+            A & (~A | B) = A & B, A | (~A & B) = A | B
+
+        - Commutativity (output is always sorted)::
+
+            A & B = B & A, A | B = B | A
 
         Other boolean objects are also in their canonical form.
         """
@@ -1397,7 +1428,9 @@ class DualBase(Function):
         Return a new expression where nested terms of this expression are
         flattened as far as possible.
 
-        E.g. A & (B & C) becomes A & B & C.
+        E.g.::
+
+            A & (B & C) becomes A & B & C.
         """
         args = list(self.args)
         i = 0
@@ -1417,8 +1450,13 @@ class DualBase(Function):
 
         See https://en.wikipedia.org/wiki/Absorption_law
 
-        Absorption: A & (A | B) = A, A | (A & B) = A
-        Negative absorption: A & (~A | B) = A & B, A | (~A & B) = A | B
+        Absorption::
+
+            A & (A | B) = A, A | (A & B) = A
+
+        Negative absorption::
+
+            A & (~A | B) = A & B, A | (~A & B) = A | B
         """
         args = list(args)
         if not args:
@@ -1505,7 +1543,8 @@ class DualBase(Function):
         """
         Return a term where the leading AND or OR terms are switched.
 
-        This is done by applying the distributive laws:
+        This is done by applying the distributive laws::
+
             A & (B|C) = (A&B) | (A&C)
             A | (B&C) = (A|B) & (A|C)
         """
@@ -1559,17 +1598,19 @@ class DualBase(Function):
 
 class AND(DualBase):
     """
-    Boolean AND operation, taking 2 or more arguments.
+    Boolean AND operation, taking two or more arguments.
 
     It can also be created by using "&" between two boolean expressions.
 
-    You can subclass to define alternative string representation.
-    For example::
+    You can subclass to define alternative string representation by overriding
+    self.operator.
+    
+    For example:
 
     >>> class AND2(AND):
-    >>>     def __init__(self, *args):
-    >>>         super(AND2, self).__init__(*args)
-    >>>         self.operator = 'AND'
+    ...     def __init__(self, *args):
+    ...         super(AND2, self).__init__(*args)
+    ...         self.operator = 'AND'
     """
 
     _pyoperator = and_operator
@@ -1585,17 +1626,19 @@ class AND(DualBase):
 
 class OR(DualBase):
     """
-    Boolean OR operation, taking 2 or more arguments
+    Boolean OR operation, taking two or more arguments
 
     It can also be created by using "|" between two boolean expressions.
 
-    You can subclass to define alternative string representation.
-    For example::
+    You can subclass to define alternative string representation by overriding
+    self.operator.
+
+    For example:
 
     >>> class OR2(OR):
-    >>>     def __init__(self, *args):
-    >>>         super(OR2, self).__init__(*args)
-    >>>         self.operator = 'OR'
+    ...     def __init__(self, *args):
+    ...         super(OR2, self).__init__(*args)
+    ...         self.operator = 'OR'
     """
 
     _pyoperator = or_operator

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,88 +1,24 @@
-# Makefile for Sphinx documentation
+# Minimal makefile for Sphinx documentation
 #
 
-# You can set these variables from the command line.
-SPHINXOPTS    =
-SPHINXBUILD   = sphinx-build
-PAPER         =
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+#SOURCEDIR     = source
+BUILDDIR      = build
 
-# Internal variables.
-PAPEROPT_a4     = -D latex_paper_size=a4
-PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d .build/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
+#clean:
+#	-rm -rf .build/&
 
-.PHONY: help clean html dirhtml pickle json htmlhelp qthelp latex changes linkcheck doctest
-
+# Put it first so that "make" without argument is like "make help".
 help:
-	@echo "Please use \`make <target>' where <target> is one of"
-	@echo "  html      to make standalone HTML files"
-	@echo "  dirhtml   to make HTML files named index.html in directories"
-	@echo "  pickle    to make pickle files"
-	@echo "  json      to make JSON files"
-	@echo "  htmlhelp  to make HTML files and a HTML help project"
-	@echo "  qthelp    to make HTML files and a qthelp project"
-	@echo "  latex     to make LaTeX files, you can set PAPER=a4 or PAPER=letter"
-	@echo "  changes   to make an overview of all changed/added/deprecated items"
-	@echo "  linkcheck to check all external links for integrity"
-	@echo "  doctest   to run all doctests embedded in the documentation (if enabled)"
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-clean:
-	-rm -rf .build/&
+.PHONY: help Makefile
 
-html:
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) .build/html
-	@echo
-	@echo "Build finished. The HTML pages are in .build/html."
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-dirhtml:
-	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) .build/dirhtml
-	@echo
-	@echo "Build finished. The HTML pages are in .build/dirhtml."
-
-pickle:
-	$(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS) .build/pickle
-	@echo
-	@echo "Build finished; now you can process the pickle files."
-
-json:
-	$(SPHINXBUILD) -b json $(ALLSPHINXOPTS) .build/json
-	@echo
-	@echo "Build finished; now you can process the JSON files."
-
-htmlhelp:
-	$(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) .build/htmlhelp
-	@echo
-	@echo "Build finished; now you can run HTML Help Workshop with the" \
-	      ".hhp project file in .build/htmlhelp."
-
-qthelp:
-	$(SPHINXBUILD) -b qthelp $(ALLSPHINXOPTS) .build/qthelp
-	@echo
-	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
-	      ".qhcp project file in .build/qthelp, like this:"
-	@echo "# qcollectiongenerator .build/qthelp/boolean.py.qhcp"
-	@echo "To view the help file:"
-	@echo "# assistant -collectionFile .build/qthelp/boolean.py.qhc"
-
-latex:
-	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) .build/latex
-	@echo
-	@echo "Build finished; the LaTeX files are in .build/latex."
-	@echo "Run \`make all-pdf' or \`make all-ps' in that directory to" \
-	      "run these through (pdf)latex."
-
-changes:
-	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) .build/changes
-	@echo
-	@echo "The overview file is in .build/changes."
-
-linkcheck:
-	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) .build/linkcheck
-	@echo
-	@echo "Link check complete; look for any errors in the above output " \
-	      "or in .build/linkcheck/output.txt."
-
-doctest:
-	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) .build/doctest
-	@echo "Testing of doctests in the sources finished, look at the " \
-	      "results in .build/doctest/output.txt."

--- a/docs/api/boolean.rst
+++ b/docs/api/boolean.rst
@@ -1,0 +1,18 @@
+boolean package
+===============
+
+.. automodule:: boolean
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+boolean.boolean module
+----------------------
+
+.. automodule:: boolean.boolean
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/modules.rst
+++ b/docs/api/modules.rst
@@ -1,0 +1,7 @@
+boolean
+=======
+
+.. toctree::
+   :maxdepth: 4
+
+   boolean

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,12 +11,16 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os
+# -- Path setup --------------------------------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.append(os.path.abspath("../boolean/"))
+# add these directories to sys.path here.
+
+import pathlib
+import sys
+
+srcdir = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, srcdir.as_posix())
 
 # -- General configuration -----------------------------------------------------
 
@@ -27,7 +31,19 @@ extensions = [
     "sphinx.ext.doctest",
     "sphinx.ext.mathjax",
     "sphinx.ext.inheritance_diagram",
+    "sphinx.ext.intersphinx",
+    "sphinxcontrib.apidoc",
 ]
+
+# Setting for sphinxcontrib.apidoc to automatically create API documentation.
+apidoc_module_dir = srcdir.joinpath('boolean').as_posix()
+apidoc_excluded_paths = [srcdir.joinpath('boolean').joinpath('test_boolean.py').as_posix()]
+apidoc_module_first = True
+
+# Reference to other Sphinx documentations
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = [".templates"]
@@ -135,7 +151,7 @@ html_theme = "default"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = [".static"]
+#html_static_path = [".static"]
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,5 +8,6 @@ boolean.py documentation
    users_guide
    concepts
    development_guide
+   API<api/modules>
    acknowledgements
 

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 
-from __future__ import absolute_import
-
-from setuptools import find_packages, setup
+from setuptools import find_packages
+from setuptools import setup
 
 long_desc = """
 
@@ -50,4 +49,22 @@ setup(
         "Topic :: Software Development :: Libraries",
         "Topic :: Utilities",
     ],
+    extras_require={
+        "testing":
+            [
+                "pytest >= 6, != 7.0.0",
+                "pytest-xdist >= 2",
+                "twine",
+                "black",
+                "isort",
+                "pycodestyle",
+            ],
+        "docs":
+            [
+                "Sphinx >= 3.3.1",
+                "sphinx-rtd-theme >= 0.5.0",
+                "doc8 >= 0.8.1",
+                "sphinxcontrib-apidoc >= 0.3.0",
+            ],
+    }
 )


### PR DESCRIPTION
Adds an API reference to the documentation. Useful for https://github.com/nexB/license-expression/pull/74 to reference from license-expression to boolean.py.

/cc @pombredanne