### PR TITLE
Fix eval of constants

### DIFF
--- a/boolean/boolean.py
+++ b/boolean/boolean.py
@@ -939,8 +939,8 @@ class _TRUE(BaseElement):
     def __repr__(self):
         return "TRUE"
 
-    def __call__(self):
-        return self
+    def __call__(self, **kwargs):
+        return True
 
     __nonzero__ = __bool__ = lambda s: True
 
@@ -967,8 +967,8 @@ class _FALSE(BaseElement):
     def __repr__(self):
         return "FALSE"
 
-    def __call__(self):
-        return self
+    def __call__(self, **kwargs):
+        return False
 
     __nonzero__ = __bool__ = lambda s: False
 


### PR DESCRIPTION
This fixes two problems. 

First is that the classes `_TRUE` and `_FALSE` don't accept keyword arguments for the `__call__` function. This means that when evaluating model with constants it raises a similar exception to this:

```
Traceback (most recent call last):
  File "/Users/tomaskrejci/Developer/quine-mccluskey/test.py", line 10, in <module>
    print(formula(**model))
          ^^^^^^^^^^^^^^^^
  File "/Users/tomaskrejci/Developer/quine-mccluskey/boolean.py/boolean/boolean.py", line 1596, in __call__
    return reduce(self._pyoperator, (a(**kwargs) for a in self.args))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tomaskrejci/Developer/quine-mccluskey/boolean.py/boolean/boolean.py", line 1596, in <genexpr>
    return reduce(self._pyoperator, (a(**kwargs) for a in self.args))
                                     ^^^^^^^^^^^
TypeError: _FALSE.__call__() got an unexpected keyword argument 'x0'
```

After adding the keyword arguments the second problem is that the `__call__` magic function returns `self` instead of the boolean value. This leads to exception similar to this:

```
Traceback (most recent call last):
  File "/Users/tomaskrejci/Developer/quine-mccluskey/fuzzer.py", line 58, in <module>
    print(k, model, ones_formula(**model))
                    ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tomaskrejci/Developer/quine-mccluskey/boolean.py/boolean/boolean.py", line 1213, in __call__
    return not self.args[0](**kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tomaskrejci/Developer/quine-mccluskey/boolean.py/boolean/boolean.py", line 1596, in __call__
    return reduce(self._pyoperator, (a(**kwargs) for a in self.args))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tomaskrejci/Developer/quine-mccluskey/boolean.py/boolean/boolean.py", line 881, in __or__
    return self.OR(self, other)
           ^^^^^^^^^^^^^^^^^^^^
  File "/Users/tomaskrejci/Developer/quine-mccluskey/boolean.py/boolean/boolean.py", line 1647, in __init__
    super(OR, self).__init__(arg1, arg2, *args)
  File "/Users/tomaskrejci/Developer/quine-mccluskey/boolean.py/boolean/boolean.py", line 1245, in __init__
    super(DualBase, self).__init__(arg1, arg2, *args)
  File "/Users/tomaskrejci/Developer/quine-mccluskey/boolean.py/boolean/boolean.py", line 1051, in __init__
    assert all(
AssertionError: Bad arguments: all arguments must be an Expression: (TRUE, False)
```

Code used to reproduce both bugs:

```python
import boolean

algebra = boolean.BooleanAlgebra()
TRUE, FALSE, NOT, AND, OR, symbol = algebra.definition()

formula = FALSE
model = {"x0": False}

# This works
print(formula())

# This does not
print(formula(**model))
```