### PR TITLE
Workaround incompatibility with Python 3.14

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -10,16 +10,21 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
      - uses: actions/checkout@v4
+
      - name: Set up Python
        uses: actions/setup-python@v5
        with:
          python-version: 3.12
+
      - name: Install pypa/build and twine
-       run: python -m pip install build twine --user
+       run: python -m pip install --user --upgrade build twine packaging pip setuptools
+
      - name: Build a binary wheel and a source tarball
        run: python -m build --sdist --wheel --outdir dist/ .
+
      - name: Check wheel and sdist with twine
        run: python -m twine check dist/*
+
      - name: Publish distribution to PyPI
        if: startsWith(github.ref, 'refs/tags')
        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -7,20 +7,21 @@ on:
 jobs:
   build-and-publish-to-pypi:
     name: Build and publish library to PyPI
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
-     - uses: actions/checkout@master
+     - uses: actions/checkout@v4
      - name: Set up Python
-       uses: actions/setup-python@v1
+       uses: actions/setup-python@v5
        with:
-         python-version: 3.9
-     - name: Install pypa/build
-       run: python -m pip install build --user
+         python-version: 3.12
+     - name: Install pypa/build and twine
+       run: python -m pip install build twine --user
      - name: Build a binary wheel and a source tarball
-       run: python -m build --sdist --wheel --outdir dist/
-        .
+       run: python -m build --sdist --wheel --outdir dist/ .
+     - name: Check wheel and sdist with twine
+       run: python -m twine check dist/*
      - name: Publish distribution to PyPI
        if: startsWith(github.ref, 'refs/tags')
-       uses: pypa/gh-action-pypi-publish@master
+       uses: pypa/gh-action-pypi-publish@release/v1
        with:
          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -58,7 +58,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14, windows-2019, windows-2022, windows-2024]
+                os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14, windows-2019, windows-2022, windows-2025]
                 python: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14-dev"]
 
         steps:

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -45,6 +45,7 @@ jobs:
           - name: Collect built sdist and wheel
             uses: actions/upload-artifact@v4
             with:
+                name: boolean-build
                 path: dist/*
 
     test_on_many_oses:
@@ -92,4 +93,5 @@ jobs:
           - name: Collect docs
             uses: actions/upload-artifact@v4
             with:
+                name: boolean-documentation
                 path: docs/build/

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -40,8 +40,8 @@ jobs:
 
           - name: Build sdist
             run: |
-                python setup.py sdist bdist_wheel
-                twine check dist/*
+                python -m build --sdist --wheel
+                python -m twine check dist/*
 
           - name: Collect built sdist
             uses: actions/upload-artifact@v4

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -59,7 +59,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-20.04, macos-11, windows-2022]
-                python: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+                python: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14-dev"]
 
         steps:
             - name: Set up Python

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -29,10 +29,10 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
     build:
       name: Build source distribution
-      runs-on: ubuntu-20.04
+      runs-on: ubuntu-24.04
 
       steps:
-          - uses: actions/checkout@v2
+          - uses: actions/checkout@v4
 
           - name: Checkout and install reqs
             run: |
@@ -44,7 +44,7 @@ jobs:
                 twine check dist/*
 
           - name: Collect built sdist
-            uses: actions/upload-artifact@v2
+            uses: actions/upload-artifact@v4
             with:
                 path: dist/*.tar.gz
 
@@ -58,16 +58,16 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-20.04, macos-11, windows-2022]
+                os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14, windows-2019, windows-2022, windows-2024]
                 python: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14-dev"]
 
         steps:
             - name: Set up Python
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v5
               with:
                 python-version: "${{ matrix.python }}"
 
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
 
             - name: Install
               run: pip install -e . -r requirements-dev.txt
@@ -77,10 +77,10 @@ jobs:
 
     docs:
       name: Generate docs
-      runs-on: ubuntu-20.04
+      runs-on: ubuntu-24.04
 
       steps:
-          - uses: actions/checkout@v2
+          - uses: actions/checkout@v4
 
           - name: Checkout and install reqs
             run: |
@@ -91,6 +91,6 @@ jobs:
                 make -C docs html
 
           - name: Collect docs
-            uses: actions/upload-artifact@v2
+            uses: actions/upload-artifact@v4
             with:
                 path: docs/build/

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -35,18 +35,17 @@ jobs:
           - uses: actions/checkout@v4
 
           - name: Checkout and install reqs
-            run: |
-                pip install --upgrade --user build twine pip setuptools
+            run: python -m pip install --user --upgrade build twine packaging pip setuptools
 
           - name: Build sdist
             run: |
                 python -m build --sdist --wheel
                 python -m twine check dist/*
 
-          - name: Collect built sdist
+          - name: Collect built sdist and wheel
             uses: actions/upload-artifact@v4
             with:
-                path: dist/*.tar.gz
+                path: dist/*
 
     test_on_many_oses:
         name: Run tests ${{ matrix.python }} on ${{ matrix.os }}

--- a/boolean/boolean.py
+++ b/boolean/boolean.py
@@ -866,7 +866,12 @@ class Expression(object):
     def __gt__(self, other):
         lt = other.__lt__(self)
         if lt is NotImplemented:
-            return not self.__lt__(other)
+            self_lt = self.__lt__(other)
+            if self_lt is NotImplemented:
+                # `return not NotImplemented`` no longer works in Python 3.14
+                return False
+            else:
+                return not self_lt
         return lt
 
     def __and__(self, other):

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,6 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
-    test_loader="unittest:TestLoader",
-    test_suite="boolean.test_boolean",
     keywords="boolean expression, boolean algebra, logic, expression parser",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
@@ -54,7 +52,9 @@ setup(
             [
                 "pytest >= 6, != 7.0.0",
                 "pytest-xdist >= 2",
-                "twine",
+            ],
+        "linting":
+            [
                 "black",
                 "isort",
                 "pycodestyle",

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,10 @@ setup(
                 "pytest >= 6, != 7.0.0",
                 "pytest-xdist >= 2",
             ],
+        "dev":
+            [
+                "twine",
+            ],
         "linting":
             [
                 "black",

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         "dev":
             [
                 "twine",
+                "build",
             ],
         "linting":
             [

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
-envlist=py36,py37,py38,py39,310
+envlist=py39,py310,py311,py312,py313,py314
 [testenv]
-commands=python setup.py test
+extras=testing
+commands=pytest -vvs boolean


### PR DESCRIPTION
Using NotImplemented in a boolean context will now raise a TypeError. It had previously raised a DeprecationWarning since Python 3.9.

Fixes: https://github.com/bastikr/boolean.py/issues/121